### PR TITLE
Feature/2281 reduce bulk send

### DIFF
--- a/pool/app/changelog/changelog.ml
+++ b/pool/app/changelog/changelog.ml
@@ -96,9 +96,9 @@ module T (R : RecordSig) = struct
 
   let make_write ?(id = Id.create ()) ?user_uuid ~entity_uuid (before : R.t) (after : R.t)
     =
-    (*** the entity_uuid could also be part of the Reord module, as a function.
-      This would probably require us to create a Record module for each model,
-      but provide more flexibility *)
+    (*** the entity_uuid could also be part of the Reord module, as a function. This would
+      probably require us to create a Record module for each model, but provide more
+      flexibility *)
     make_changes before after
     |> CCOption.map (fun changes ->
       Write.

--- a/pool/app/custom_field/custom_field.ml
+++ b/pool/app/custom_field/custom_field.ml
@@ -227,8 +227,7 @@ let validate_partial_update
     custom_field |> custom |> check_version old_v |> Lwt_result.lift
 ;;
 
-(* Replace all ids with the names of the custom_fields and
-   custom_field_options *)
+(* Replace all ids with the names of the custom_fields and custom_field_options *)
 let changelog_to_human pool language ({ Changelog.changes; _ } as changelog) =
   let open Changelog.Changes in
   let id_of_string = CCFun.(Id.validate %> CCOption.of_result) in

--- a/pool/app/custom_field/version_history.ml
+++ b/pool/app/custom_field/version_history.ml
@@ -50,8 +50,8 @@ module AnswerRecord = struct
   let yojson_of_t record =
     let field_uuid = "custom_field_uuid" in
     let json = yojson_of_t record in
-    (* Wrap the record json in an assoc, where the uuid is the key, to make sure
-       the field name is visible in the changelog *)
+    (* Wrap the record json in an assoc, where the uuid is the key, to make sure the field
+       name is visible in the changelog *)
     match json with
     | `List [ `String _; `Assoc answer ] ->
       CCList.assoc_opt ~eq:CCString.equal field_uuid answer

--- a/pool/app/email/email.mli
+++ b/pool/app/email/email.mli
@@ -340,3 +340,4 @@ val sent
   -> event
 
 val bulksent : dispatch list -> event
+val bulksent_opt : dispatch list -> event list

--- a/pool/app/email/event.ml
+++ b/pool/app/email/event.ml
@@ -77,6 +77,8 @@ let create_sent ?id ?message_template ?job_ctx ?new_email_address ?new_smtp_auth
   |> sent ?new_email_address ?new_smtp_auth_id
 ;;
 
+let bulksent_opt jobs = if CCList.is_empty jobs then [] else [ BulkSent jobs ]
+
 let handle_event pool : event -> unit Lwt.t = function
   | Sent ({ job; id; message_template; job_ctx }, new_email_address, new_smtp_auth_id) ->
     Email_service.dispatch
@@ -87,6 +89,7 @@ let handle_event pool : event -> unit Lwt.t = function
       ?job_ctx
       pool
       job
+  | BulkSent [] -> Lwt.return_unit
   | BulkSent jobs ->
     let jobs =
       CCList.map

--- a/pool/app/filter/entity.ml
+++ b/pool/app/filter/entity.ml
@@ -156,8 +156,8 @@ module Key = struct
     match read_hardcoded yojson with
     | Some h -> Ok (Hardcoded h)
     | None ->
-      (* The "validate_query" function will check, if the id belongs to an
-         existing custom field *)
+      (* The "validate_query" function will check, if the id belongs to an existing custom
+         field *)
       (match yojson with
        | `String id -> Ok (CustomField (id |> Custom_field.Id.of_string))
        | _ -> Error Pool_message.(Error.Invalid Field.Key))
@@ -359,8 +359,8 @@ module Operator = struct
     ;;
 
     let to_sql = function
-      (* List operators are used to query custom field answers by their value
-         which store json arrays *)
+      (* List operators are used to query custom field answers by their value which store
+         json arrays *)
       | ContainsSome | ContainsAll -> "LIKE"
       | ContainsNone -> "NOT LIKE"
     ;;

--- a/pool/app/filter/repo/repo_utils.ml
+++ b/pool/app/filter/repo/repo_utils.ml
@@ -169,8 +169,7 @@ let add_list_condition subquery dyn ids =
     Error Message.(Error.Invalid Field.Operator)
 ;;
 
-(* The subquery returns any contacts that has been an assignment to an
-   experiment. *)
+(* The subquery returns any contacts that has been an assignment to an experiment. *)
 let assignment_subquery dyn operator ids =
   let open CCResult in
   let* dyn, query_params = add_uuid_param dyn ids in
@@ -226,9 +225,8 @@ let invitation_subquery dyn operator ids =
   add_list_condition subquery dyn ids operator
 ;;
 
-(* The subquery does not return any contacts that have shown up at a session of
-   the current experiment. It does not make a difference, if they
-   participated. *)
+(* The subquery does not return any contacts that have shown up at a session of the
+   current experiment. It does not make a difference, if they participated. *)
 let participation_subquery dyn operator ids =
   let open CCResult in
   let* dyn, query_params = add_uuid_param dyn ids in

--- a/pool/app/guard/repo.ml
+++ b/pool/app/guard/repo.ml
@@ -243,9 +243,8 @@ end
 let src = Logs.Src.create "guard"
 
 module Cache = struct
-  (* TODO: Once the guardian package has a cached version, this implementation
-     can be updated/removed (Issue:
-     https://github.com/uzh/guardian/issues/11) *)
+  (* TODO: Once the guardian package has a cached version, this implementation can be
+     updated/removed (Issue: https://github.com/uzh/guardian/issues/11) *)
   open CCCache
 
   let equal_find_actor (l1, a1) (l2, a2) =

--- a/pool/app/message_template/repo/repo_sql.ml
+++ b/pool/app/message_template/repo/repo_sql.ml
@@ -210,8 +210,8 @@ let find_by_label_and_language_to_send pool ?entity_uuids label language =
   Database.find pool request pv
 ;;
 
-(* The template are prioritised according to the entity_uuids list, from left to
-   right. If none are found, the default template will be returned. *)
+(* The template are prioritised according to the entity_uuids list, from left to right. If
+   none are found, the default template will be returned. *)
 let find_all_by_label_to_send pool ?entity_uuids languages label =
   let open Utils.Lwt_result.Infix in
   if CCList.is_empty languages
@@ -233,8 +233,7 @@ let find_all_by_label_to_send pool ?entity_uuids languages label =
 ;;
 
 let find_entity_defaults_by_label pool ?entity_uuids languages label =
-  (* Removing the last uuid from the entity_uuids to so the entity default is
-     returned *)
+  (* Removing the last uuid from the entity_uuids to so the entity default is returned *)
   let entity_uuids =
     match entity_uuids with
     | None | Some [] | Some (_ :: []) -> []

--- a/pool/app/pool_context/entity.ml
+++ b/pool/app/pool_context/entity.ml
@@ -1,7 +1,7 @@
 open Sexplib.Conv
 
-(* TODO: Service.User.t for Admin and Root are placeholders and should be
-   replaced, when guadrian is implemented *)
+(* TODO: Service.User.t for Admin and Root are placeholders and should be replaced, when
+   guadrian is implemented *)
 type user =
   | Admin of Admin.t
   | Contact of Contact.t

--- a/pool/app/pool_database/migrations/migration_custom_field_answers.ml
+++ b/pool/app/pool_database/migrations/migration_custom_field_answers.ml
@@ -35,8 +35,8 @@ let make_value_nullable =
     |sql}
 ;;
 
-(* To keep the migrations clean, I added a default value (Versions only matter
-   when mutliple people are updating) *)
+(* To keep the migrations clean, I added a default value (Versions only matter when
+   mutliple people are updating) *)
 let add_versions_and_admin_values =
   Database.Migration.Step.create
     ~label:"add versions and admin values"

--- a/pool/app/reminder/service.ml
+++ b/pool/app/reminder/service.ml
@@ -41,40 +41,41 @@ let create_email_events data =
   data
   |> CCList.fold_left
        (fun (session_events, emails) (session, reminders) ->
-          ( (Session.EmailReminderSent session |> Pool_event.session) :: session_events
-          , reminders @ emails ))
+         ( (Session.EmailReminderSent session |> Pool_event.session) :: session_events
+         , reminders @ emails ))
        ([], [])
   |> fun (session_events, emails) ->
-  (Email.BulkSent emails |> Pool_event.email) :: session_events
+  (Email.bulksent_opt emails |> Pool_event.(map email)) @ session_events
 ;;
 
 let create_text_message_events data =
   data
   |> CCList.fold_left
        (fun (session_events, text_messages) (session, reminders) ->
-          ( (Session.TextMsgReminderSent session |> Pool_event.session) :: session_events
-          , reminders @ text_messages ))
+         ( (Session.TextMsgReminderSent session |> Pool_event.session) :: session_events
+         , reminders @ text_messages ))
        ([], [])
   |> fun (session_events, text_messages) ->
-  (Text_message.BulkSent text_messages |> Pool_event.text_message) :: session_events
+  (Text_message.bulksent_opt text_messages |> Pool_event.(map text_message))
+  @ session_events
 ;;
 
 let create_reminder_events
-      ({ Pool_tenant.database_label; _ } as tenant)
-      email_reminders
-      text_message_reminders
+  ({ Pool_tenant.database_label; _ } as tenant)
+  email_reminders
+  text_message_reminders
   =
   let open Utils.Lwt_result.Infix in
   let%lwt sys_languages = Settings.find_languages database_label in
   let* email_events =
     Lwt_list.map_s
       (fun session ->
-         Experiment.find_of_session
-           database_label
-           (Session.Id.to_common session.Session.id)
-         >>= fun experiment ->
-         create_reminder_emails database_label tenant sys_languages session experiment
-         >|+ fun emails -> session, emails)
+        Experiment.find_of_session
+          database_label
+          (Session.Id.to_common session.Session.id)
+        >>= fun experiment ->
+        create_reminder_emails database_label tenant sys_languages session experiment
+        >|+ fun emails -> session, emails)
       email_reminders
     ||> CCResult.flatten_l
     >|+ create_email_events
@@ -82,17 +83,17 @@ let create_reminder_events
   let* text_msg_events =
     Lwt_list.map_s
       (fun session ->
-         Experiment.find_of_session
-           database_label
-           (Session.Id.to_common session.Session.id)
-         >>= fun experiment ->
-         create_reminder_text_messages
-           database_label
-           tenant
-           sys_languages
-           session
-           experiment
-         >|+ fun emails -> session, emails)
+        Experiment.find_of_session
+          database_label
+          (Session.Id.to_common session.Session.id)
+        >>= fun experiment ->
+        create_reminder_text_messages
+          database_label
+          tenant
+          sys_languages
+          session
+          experiment
+        >|+ fun emails -> session, emails)
       text_message_reminders
     ||> CCResult.flatten_l
     >|+ create_text_message_events

--- a/pool/app/reminder/service.ml
+++ b/pool/app/reminder/service.ml
@@ -41,8 +41,8 @@ let create_email_events data =
   data
   |> CCList.fold_left
        (fun (session_events, emails) (session, reminders) ->
-         ( (Session.EmailReminderSent session |> Pool_event.session) :: session_events
-         , reminders @ emails ))
+          ( (Session.EmailReminderSent session |> Pool_event.session) :: session_events
+          , reminders @ emails ))
        ([], [])
   |> fun (session_events, emails) ->
   (Email.bulksent_opt emails |> Pool_event.(map email)) @ session_events
@@ -52,8 +52,8 @@ let create_text_message_events data =
   data
   |> CCList.fold_left
        (fun (session_events, text_messages) (session, reminders) ->
-         ( (Session.TextMsgReminderSent session |> Pool_event.session) :: session_events
-         , reminders @ text_messages ))
+          ( (Session.TextMsgReminderSent session |> Pool_event.session) :: session_events
+          , reminders @ text_messages ))
        ([], [])
   |> fun (session_events, text_messages) ->
   (Text_message.bulksent_opt text_messages |> Pool_event.(map text_message))
@@ -61,21 +61,21 @@ let create_text_message_events data =
 ;;
 
 let create_reminder_events
-  ({ Pool_tenant.database_label; _ } as tenant)
-  email_reminders
-  text_message_reminders
+      ({ Pool_tenant.database_label; _ } as tenant)
+      email_reminders
+      text_message_reminders
   =
   let open Utils.Lwt_result.Infix in
   let%lwt sys_languages = Settings.find_languages database_label in
   let* email_events =
     Lwt_list.map_s
       (fun session ->
-        Experiment.find_of_session
-          database_label
-          (Session.Id.to_common session.Session.id)
-        >>= fun experiment ->
-        create_reminder_emails database_label tenant sys_languages session experiment
-        >|+ fun emails -> session, emails)
+         Experiment.find_of_session
+           database_label
+           (Session.Id.to_common session.Session.id)
+         >>= fun experiment ->
+         create_reminder_emails database_label tenant sys_languages session experiment
+         >|+ fun emails -> session, emails)
       email_reminders
     ||> CCResult.flatten_l
     >|+ create_email_events
@@ -83,17 +83,17 @@ let create_reminder_events
   let* text_msg_events =
     Lwt_list.map_s
       (fun session ->
-        Experiment.find_of_session
-          database_label
-          (Session.Id.to_common session.Session.id)
-        >>= fun experiment ->
-        create_reminder_text_messages
-          database_label
-          tenant
-          sys_languages
-          session
-          experiment
-        >|+ fun emails -> session, emails)
+         Experiment.find_of_session
+           database_label
+           (Session.Id.to_common session.Session.id)
+         >>= fun experiment ->
+         create_reminder_text_messages
+           database_label
+           tenant
+           sys_languages
+           session
+           experiment
+         >|+ fun emails -> session, emails)
       text_message_reminders
     ||> CCResult.flatten_l
     >|+ create_text_message_events

--- a/pool/app/system_event/repo/repo.ml
+++ b/pool/app/system_event/repo/repo.ml
@@ -98,8 +98,8 @@ module Sql = struct
 
     let insert_request =
       let open Caqti_request.Infix in
-      (* TODO: Consider using UPDATE ON DUPLICATE when event_id/service_id pair
-         should be unique *)
+      (* TODO: Consider using UPDATE ON DUPLICATE when event_id/service_id pair should be
+         unique *)
       {sql|
         INSERT INTO pool_system_event_logs (
           event_uuid,

--- a/pool/app/text_message/event.ml
+++ b/pool/app/text_message/event.ml
@@ -31,7 +31,7 @@ let handle_event pool : event -> unit Lwt.t = function
   | BulkSent jobs ->
     Lwt_list.iter_s
       (fun { job; id; message_template; job_ctx } ->
-        Text_message_service.dispatch ?id ?message_template ?job_ctx pool job)
+         Text_message_service.dispatch ?id ?message_template ?job_ctx pool job)
       jobs
   | ReportCreated report -> Repo.insert_report pool report
 ;;

--- a/pool/app/text_message/text_message.mli
+++ b/pool/app/text_message/text_message.mli
@@ -130,3 +130,5 @@ val create_sent
   -> event
 
 val sent : ?new_recipient:Pool_user.CellPhone.t -> job -> event
+val bulksent : job list -> event
+val bulksent_opt : job list -> event list

--- a/pool/app/utils/lwt_trace.ml
+++ b/pool/app/utils/lwt_trace.ml
@@ -1,6 +1,6 @@
-(* This module exists to add useful monadic infix operators and to ensure all
-   monadic actions are implemented using the lwt ppx to always present clean
-   stack/back traces (https://ocsigen.org/lwt/latest/manual/manual and
+(* This module exists to add useful monadic infix operators and to ensure all monadic
+   actions are implemented using the lwt ppx to always present clean stack/back traces
+   (https://ocsigen.org/lwt/latest/manual/manual and
    https://github.com/ocsigen/lwt/blob/6ce3d557798d2b5736fb458b697cc3eaa13c461e/src/core/lwt.ml#L1694) *)
 
 module Infix = struct

--- a/pool/app/utils/utils.ml
+++ b/pool/app/utils/utils.ml
@@ -109,8 +109,7 @@ end
 module Html = struct
   open Tyxml.Html
 
-  (* placed here due to circular dependency between email and http_utils
-     library *)
+  (* placed here due to circular dependency between email and http_utils library *)
   let handle_line_breaks finally_fcn str =
     finally_fcn
     @@

--- a/pool/cqrs_command/admin_command.ml
+++ b/pool/cqrs_command/admin_command.ml
@@ -33,8 +33,8 @@ end = struct
     let* () =
       Pool_user.EmailAddress.validate allowed_email_suffixes command.User_command.email
     in
-    (* TODO: pass Id or Tenant to Admin.Created function as option to further
-       pass down to permissions *)
+    (* TODO: pass Id or Tenant to Admin.Created function as option to further pass down to
+       permissions *)
     let admin : Admin.create =
       User_command.
         { id

--- a/pool/cqrs_command/assignment_command.ml
+++ b/pool/cqrs_command/assignment_command.ml
@@ -56,7 +56,7 @@ let assignment_creation_and_confirmation_events
   let email_event = Email.sent confirmation_email |> Pool_event.email in
   let create_events =
     Created (main_assignment, session.Session.id) :: follow_up_events
-    |> CCList.map Pool_event.assignment
+    |> Pool_event.(map assignment)
   in
   Ok (email_event :: create_events)
 ;;

--- a/pool/cqrs_command/assignment_command.ml
+++ b/pool/cqrs_command/assignment_command.ml
@@ -575,9 +575,8 @@ end = struct
 
   let handle ?(tags = Logs.Tag.empty) (assignment_events, emails) =
     Logs.info ~src (fun m -> m "Handle command UpdateMatchesFilter" ~tags);
-    Ok
-      ((assignment_events |> CCList.map Pool_event.assignment)
-       @ [ Email.BulkSent emails |> Pool_event.email ])
+    let email_events = Email.bulksent_opt emails |> Pool_event.(map email) in
+    Ok (Pool_event.(map assignment) assignment_events @ email_events)
   ;;
 
   let effects id = Session.Guard.Access.update id

--- a/pool/cqrs_command/contact_command.ml
+++ b/pool/cqrs_command/contact_command.ml
@@ -276,9 +276,8 @@ end = struct
   let handle ?(tags = Logs.Tag.empty) ({ contacts; emails } : t) =
     Logs.info ~src (fun m -> m "Handle command SendProfileUpdateTrigger" ~tags);
     Ok
-      [ Contact.ProfileUpdateTriggeredAtUpdated contacts |> Pool_event.contact
-      ; Email.BulkSent emails |> Pool_event.email
-      ]
+      ((Contact.ProfileUpdateTriggeredAtUpdated contacts |> Pool_event.contact)
+       :: (Email.bulksent_opt emails |> Pool_event.(map email)))
   ;;
 
   let effects = Contact.Guard.Access.update

--- a/pool/cqrs_command/custom_field_settings_command.ml
+++ b/pool/cqrs_command/custom_field_settings_command.ml
@@ -41,7 +41,7 @@ end = struct
            | Some (_ : string) | None -> `Drop)
         fields
     in
-    active @ inactive |> CCList.map Pool_event.custom_field |> CCResult.return
+    active @ inactive |> Pool_event.(map custom_field) |> CCResult.return
   ;;
 
   let effects = Custom_field.Guard.Access.create

--- a/pool/cqrs_command/experiment_command.ml
+++ b/pool/cqrs_command/experiment_command.ml
@@ -544,7 +544,7 @@ end = struct
       ; matcher_notification_sent = MatcherNotificationSent.create false
       }
     in
-    let assignment_events = assignment_events |> CCList.map Pool_event.assignment in
+    let assignment_events = assignment_events |> Pool_event.(map assignment) in
     let email_event = Email.bulksent_opt emails |> Pool_event.(map email) in
     Ok
       ([ Filter.Created filter |> Pool_event.filter

--- a/pool/cqrs_command/experiment_command.ml
+++ b/pool/cqrs_command/experiment_command.ml
@@ -33,25 +33,25 @@ type command =
   }
 
 let default_command
-  title
-  public_title
-  internal_description
-  public_description
-  language
-  cost_center
-  contact_email
-  direct_registration_disabled
-  registration_disabled
-  allow_uninvited_signup
-  external_data_required
-  show_external_data_id_links
-  experiment_type
-  assignment_without_session
-  survey_url
-  email_session_reminder_lead_time
-  email_session_reminder_lead_time_unit
-  text_message_session_reminder_lead_time
-  text_message_session_reminder_lead_time_unit
+      title
+      public_title
+      internal_description
+      public_description
+      language
+      cost_center
+      contact_email
+      direct_registration_disabled
+      registration_disabled
+      allow_uninvited_signup
+      external_data_required
+      show_external_data_id_links
+      experiment_type
+      assignment_without_session
+      survey_url
+      email_session_reminder_lead_time
+      email_session_reminder_lead_time_unit
+      text_message_session_reminder_lead_time
+      text_message_session_reminder_lead_time_unit
   : (command, Pool_message.Error.t) Result.t
   =
   let open CCResult in
@@ -176,28 +176,28 @@ end = struct
   type t = command
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ?(id = Id.create ())
-    ?organisational_unit
-    ?smtp_auth
-    ({ title
-     ; public_title
-     ; internal_description
-     ; public_description
-     ; language
-     ; cost_center
-     ; contact_email
-     ; direct_registration_disabled
-     ; registration_disabled
-     ; allow_uninvited_signup
-     ; external_data_required
-     ; show_external_data_id_links
-     ; experiment_type
-     ; online_experiment
-     ; email_session_reminder_lead_time
-     ; text_message_session_reminder_lead_time
-     } :
-      command)
+        ?(tags = Logs.Tag.empty)
+        ?(id = Id.create ())
+        ?organisational_unit
+        ?smtp_auth
+        ({ title
+         ; public_title
+         ; internal_description
+         ; public_description
+         ; language
+         ; cost_center
+         ; contact_email
+         ; direct_registration_disabled
+         ; registration_disabled
+         ; allow_uninvited_signup
+         ; external_data_required
+         ; show_external_data_id_links
+         ; experiment_type
+         ; online_experiment
+         ; email_session_reminder_lead_time
+         ; text_message_session_reminder_lead_time
+         } :
+          command)
     =
     Logs.info ~src (fun m -> m "Handle command Create" ~tags);
     let open CCResult in
@@ -255,29 +255,29 @@ end = struct
   type t = command
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ~session_count
-    experiment
-    organisational_unit
-    smtp_auth
-    ({ title
-     ; public_title
-     ; internal_description
-     ; public_description
-     ; language
-     ; cost_center
-     ; contact_email
-     ; direct_registration_disabled
-     ; registration_disabled
-     ; allow_uninvited_signup
-     ; external_data_required
-     ; show_external_data_id_links
-     ; experiment_type
-     ; online_experiment
-     ; email_session_reminder_lead_time
-     ; text_message_session_reminder_lead_time
-     } :
-      t)
+        ?(tags = Logs.Tag.empty)
+        ~session_count
+        experiment
+        organisational_unit
+        smtp_auth
+        ({ title
+         ; public_title
+         ; internal_description
+         ; public_description
+         ; language
+         ; cost_center
+         ; contact_email
+         ; direct_registration_disabled
+         ; registration_disabled
+         ; allow_uninvited_signup
+         ; external_data_required
+         ; show_external_data_id_links
+         ; experiment_type
+         ; online_experiment
+         ; email_session_reminder_lead_time
+         ; text_message_session_reminder_lead_time
+         } :
+          t)
     =
     let open CCResult in
     Logs.info ~src (fun m -> m "Handle command Update" ~tags);
@@ -374,9 +374,9 @@ end = struct
     }
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ?system_event_id
-    { experiment; session_count; mailings; experimenters; assistants; templates }
+        ?(tags = Logs.Tag.empty)
+        ?system_event_id
+        { experiment; session_count; mailings; experimenters; assistants; templates }
     =
     let open CCFun in
     let open CCResult in
@@ -591,11 +591,11 @@ end = struct
   ;;
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    experiment
-    (assignment_events, emails)
-    filter
-    updated_fitler
+        ?(tags = Logs.Tag.empty)
+        experiment
+        (assignment_events, emails)
+        filter
+        updated_fitler
     =
     Logs.info ~src (fun m -> m "Handle command UpdateFilter" ~tags);
     let open CCResult in

--- a/pool/cqrs_command/experiment_command.ml
+++ b/pool/cqrs_command/experiment_command.ml
@@ -33,25 +33,25 @@ type command =
   }
 
 let default_command
-      title
-      public_title
-      internal_description
-      public_description
-      language
-      cost_center
-      contact_email
-      direct_registration_disabled
-      registration_disabled
-      allow_uninvited_signup
-      external_data_required
-      show_external_data_id_links
-      experiment_type
-      assignment_without_session
-      survey_url
-      email_session_reminder_lead_time
-      email_session_reminder_lead_time_unit
-      text_message_session_reminder_lead_time
-      text_message_session_reminder_lead_time_unit
+  title
+  public_title
+  internal_description
+  public_description
+  language
+  cost_center
+  contact_email
+  direct_registration_disabled
+  registration_disabled
+  allow_uninvited_signup
+  external_data_required
+  show_external_data_id_links
+  experiment_type
+  assignment_without_session
+  survey_url
+  email_session_reminder_lead_time
+  email_session_reminder_lead_time_unit
+  text_message_session_reminder_lead_time
+  text_message_session_reminder_lead_time_unit
   : (command, Pool_message.Error.t) Result.t
   =
   let open CCResult in
@@ -176,28 +176,28 @@ end = struct
   type t = command
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ?(id = Id.create ())
-        ?organisational_unit
-        ?smtp_auth
-        ({ title
-         ; public_title
-         ; internal_description
-         ; public_description
-         ; language
-         ; cost_center
-         ; contact_email
-         ; direct_registration_disabled
-         ; registration_disabled
-         ; allow_uninvited_signup
-         ; external_data_required
-         ; show_external_data_id_links
-         ; experiment_type
-         ; online_experiment
-         ; email_session_reminder_lead_time
-         ; text_message_session_reminder_lead_time
-         } :
-          command)
+    ?(tags = Logs.Tag.empty)
+    ?(id = Id.create ())
+    ?organisational_unit
+    ?smtp_auth
+    ({ title
+     ; public_title
+     ; internal_description
+     ; public_description
+     ; language
+     ; cost_center
+     ; contact_email
+     ; direct_registration_disabled
+     ; registration_disabled
+     ; allow_uninvited_signup
+     ; external_data_required
+     ; show_external_data_id_links
+     ; experiment_type
+     ; online_experiment
+     ; email_session_reminder_lead_time
+     ; text_message_session_reminder_lead_time
+     } :
+      command)
     =
     Logs.info ~src (fun m -> m "Handle command Create" ~tags);
     let open CCResult in
@@ -255,29 +255,29 @@ end = struct
   type t = command
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ~session_count
-        experiment
-        organisational_unit
-        smtp_auth
-        ({ title
-         ; public_title
-         ; internal_description
-         ; public_description
-         ; language
-         ; cost_center
-         ; contact_email
-         ; direct_registration_disabled
-         ; registration_disabled
-         ; allow_uninvited_signup
-         ; external_data_required
-         ; show_external_data_id_links
-         ; experiment_type
-         ; online_experiment
-         ; email_session_reminder_lead_time
-         ; text_message_session_reminder_lead_time
-         } :
-          t)
+    ?(tags = Logs.Tag.empty)
+    ~session_count
+    experiment
+    organisational_unit
+    smtp_auth
+    ({ title
+     ; public_title
+     ; internal_description
+     ; public_description
+     ; language
+     ; cost_center
+     ; contact_email
+     ; direct_registration_disabled
+     ; registration_disabled
+     ; allow_uninvited_signup
+     ; external_data_required
+     ; show_external_data_id_links
+     ; experiment_type
+     ; online_experiment
+     ; email_session_reminder_lead_time
+     ; text_message_session_reminder_lead_time
+     } :
+      t)
     =
     let open CCResult in
     Logs.info ~src (fun m -> m "Handle command Update" ~tags);
@@ -374,9 +374,9 @@ end = struct
     }
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ?system_event_id
-        { experiment; session_count; mailings; experimenters; assistants; templates }
+    ?(tags = Logs.Tag.empty)
+    ?system_event_id
+    { experiment; session_count; mailings; experimenters; assistants; templates }
     =
     let open CCFun in
     let open CCResult in
@@ -545,13 +545,13 @@ end = struct
       }
     in
     let assignment_events = assignment_events |> CCList.map Pool_event.assignment in
-    let email_event = Email.BulkSent emails |> Pool_event.email in
+    let email_event = Email.bulksent_opt emails |> Pool_event.(map email) in
     Ok
       ([ Filter.Created filter |> Pool_event.filter
        ; Experiment.Updated (experiment, updated) |> Pool_event.experiment
        ]
        @ assignment_events
-       @ [ email_event ])
+       @ email_event)
   ;;
 
   let effects id =
@@ -591,24 +591,24 @@ end = struct
   ;;
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        experiment
-        (assignment_events, emails)
-        filter
-        updated_fitler
+    ?(tags = Logs.Tag.empty)
+    experiment
+    (assignment_events, emails)
+    filter
+    updated_fitler
     =
     Logs.info ~src (fun m -> m "Handle command UpdateFilter" ~tags);
     let open CCResult in
-    let assignment_events = assignment_events |> CCList.map Pool_event.assignment in
-    let email_event = Email.BulkSent emails |> Pool_event.email in
+    let assignment_events = assignment_events |> Pool_event.(map assignment) in
+    let email_event = Email.bulksent_opt emails |> Pool_event.(map email) in
     let updated_experiiment =
       { experiment with matcher_notification_sent = MatcherNotificationSent.create false }
     in
     Ok
       ([ Experiment.Updated (experiment, updated_experiiment) |> Pool_event.experiment
        ; Filter.Updated (filter, updated_fitler) |> Pool_event.filter
-       ; email_event
        ]
+       @ email_event
        @ assignment_events)
   ;;
 

--- a/pool/cqrs_command/guardian_command.ml
+++ b/pool/cqrs_command/guardian_command.ml
@@ -131,7 +131,7 @@ end = struct
         | true -> if value then `Drop else `Right role_permission)
     in
     Guard.RolePermissionSaved create :: (destroy |> CCList.map Guard.rolepermissiondeleted)
-    |> CCList.map Pool_event.guard
+    |> Pool_event.(map guard)
     |> CCResult.return
   ;;
 

--- a/pool/cqrs_command/invitation_command.ml
+++ b/pool/cqrs_command/invitation_command.ml
@@ -53,8 +53,8 @@ end = struct
         Ok
           ([ Invitation.(Created { contacts; mailing; experiment })
              |> Pool_event.invitation
-           ; Email.BulkSent emails |> Pool_event.email
            ]
+           @ (Email.bulksent_opt emails |> Pool_event.(map email))
            @ contact_update_on_invitation_sent contacts)
       | Error err -> Error err)
   ;;

--- a/pool/cqrs_command/session_command.ml
+++ b/pool/cqrs_command/session_command.ml
@@ -12,18 +12,18 @@ type reschedule =
 let src = Logs.Src.create "session.cqrs"
 
 let command
-      start
-      duration
-      duration_unit
-      internal_description
-      public_description
-      max_participants
-      min_participants
-      overbook
-      email_reminder_lead_time
-      email_reminder_lead_time_unit
-      text_message_reminder_lead_time
-      text_message_reminder_lead_time_unit
+  start
+  duration
+  duration_unit
+  internal_description
+  public_description
+  max_participants
+  min_participants
+  overbook
+  email_reminder_lead_time
+  email_reminder_lead_time_unit
+  text_message_reminder_lead_time
+  text_message_reminder_lead_time_unit
   : Session.base
   =
   Session.
@@ -65,14 +65,14 @@ let schema =
 ;;
 
 let decode_time_durations
-      { Session.duration
-      ; duration_unit
-      ; email_reminder_lead_time
-      ; email_reminder_lead_time_unit
-      ; text_message_reminder_lead_time
-      ; text_message_reminder_lead_time_unit
-      ; _
-      }
+  { Session.duration
+  ; duration_unit
+  ; email_reminder_lead_time
+  ; email_reminder_lead_time_unit
+  ; text_message_reminder_lead_time
+  ; text_message_reminder_lead_time_unit
+  ; _
+  }
   =
   let open CCResult in
   let open Pool_common in
@@ -96,7 +96,7 @@ let starts_after_parent parent_session start =
   CCOption.map_or
     ~default:false
     (fun (s : Session.t) ->
-       Ptime.is_earlier ~than:(Start.value s.start) (Start.value start))
+      Ptime.is_earlier ~than:(Start.value s.start) (Start.value start))
     parent_session
 ;;
 
@@ -106,7 +106,7 @@ let validate_start follow_up_sessions parent_session start =
   let starts_before_followups =
     CCList.exists
       (fun (follow_up : Session.t) ->
-         Ptime.is_earlier ~than:(Start.value start) (Start.value follow_up.start))
+        Ptime.is_earlier ~than:(Start.value start) (Start.value follow_up.start))
       follow_up_sessions
   in
   if starts_after_parent parent_session start || starts_before_followups
@@ -143,21 +143,21 @@ end = struct
   let schema = schema
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ?parent_session
-        ?session_id
-        experiment
-        location
-        (Session.
-           { start
-           ; internal_description
-           ; public_description
-           ; max_participants
-           ; min_participants
-           ; overbook
-           ; _
-           } as command :
-          Session.base)
+    ?(tags = Logs.Tag.empty)
+    ?parent_session
+    ?session_id
+    experiment
+    location
+    (Session.
+       { start
+       ; internal_description
+       ; public_description
+       ; max_participants
+       ; min_participants
+       ; overbook
+       ; _
+       } as command :
+      Session.base)
     =
     Logs.info ~src (fun m -> m "Handle command Create" ~tags);
     let open CCResult in
@@ -200,11 +200,11 @@ end = struct
 end
 
 let time_window_command
-      start
-      end_at
-      internal_description
-      public_description
-      max_participants
+  start
+  end_at
+  internal_description
+  public_description
+  max_participants
   : Time_window.create
   =
   let open Time_window in
@@ -242,16 +242,16 @@ end = struct
   type t = Time_window.create
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ~overlapps
-        ?id
-        experiment
-        { Time_window.start
-        ; end_at
-        ; internal_description
-        ; public_description
-        ; max_participants
-        }
+    ?(tags = Logs.Tag.empty)
+    ~overlapps
+    ?id
+    experiment
+    { Time_window.start
+    ; end_at
+    ; internal_description
+    ; public_description
+    ; max_participants
+    }
     =
     Logs.info ~src (fun m -> m "Handle command CreateTimeWindow" ~tags);
     let open CCResult in
@@ -301,15 +301,15 @@ end = struct
   type t = Time_window.create
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ~overlapps
-        time_window
-        { Time_window.start
-        ; end_at
-        ; internal_description
-        ; public_description
-        ; max_participants
-        }
+    ?(tags = Logs.Tag.empty)
+    ~overlapps
+    time_window
+    { Time_window.start
+    ; end_at
+    ; internal_description
+    ; public_description
+    ; max_participants
+    }
     =
     Logs.info ~src (fun m -> m "Handle command UpdateTimeWindow" ~tags);
     let open CCResult in
@@ -374,23 +374,23 @@ end = struct
     urlencoded
     |> CCList.fold_left
          (fun acc (key, value) ->
-            let open CCString in
-            match acc with
-            | Error _ -> acc
-            | Ok (acc : (int * (Session.Id.t * Session.Start.t) list) list) ->
-              key
-              |> replace ~which:`Right ~sub:"]" ~by:""
-              |> split ~by:"["
-              |> (function
-               | [ id; group ] ->
-                 parse_row id group value
-                 >|= fun (group, data) ->
-                 let eq = CCInt.equal in
-                 let current =
-                   CCList.assoc_opt ~eq group acc |> CCOption.value ~default:[]
-                 in
-                 CCList.Assoc.set ~eq group (data :: current) acc
-               | _ -> Ok acc))
+           let open CCString in
+           match acc with
+           | Error _ -> acc
+           | Ok (acc : (int * (Session.Id.t * Session.Start.t) list) list) ->
+             key
+             |> replace ~which:`Right ~sub:"]" ~by:""
+             |> split ~by:"["
+             |> (function
+              | [ id; group ] ->
+                parse_row id group value
+                >|= fun (group, data) ->
+                let eq = CCInt.equal in
+                let current =
+                  CCList.assoc_opt ~eq group acc |> CCOption.value ~default:[]
+                in
+                CCList.Assoc.set ~eq group (data :: current) acc
+              | _ -> Ok acc))
          (Ok [])
   ;;
 
@@ -398,20 +398,20 @@ end = struct
     let open CCResult in
     Logs.info ~src (fun m -> m "Handle command Duplicate" ~tags);
     let validate_and_merge_session
-          ?parent
-          { Session.internal_description
-          ; public_description
-          ; email_reminder_lead_time
-          ; text_message_reminder_lead_time
-          ; duration
-          ; location
-          ; max_participants
-          ; min_participants
-          ; overbook
-          ; experiment
-          ; _
-          }
-          start
+      ?parent
+      { Session.internal_description
+      ; public_description
+      ; email_reminder_lead_time
+      ; text_message_reminder_lead_time
+      ; duration
+      ; location
+      ; max_participants
+      ; min_participants
+      ; overbook
+      ; experiment
+      ; _
+      }
+      start
       =
       if starts_after_parent parent start
       then Error Pool_message.Error.FollowUpIsEarlierThanMain
@@ -445,19 +445,19 @@ end = struct
     |> parse_urlencoded
     >>= CCList.fold_left
           (fun acc (_, form_data) ->
-             acc
-             >>= fun acc ->
-             let sessions =
-               let* parent_clone =
-                 build_session ?parent:parent_session form_data session
-               in
-               let* followup_clones =
-                 let open CCList in
-                 followups >|= build_session ~parent:parent_clone form_data |> all_ok
-               in
-               Ok (parent_clone :: followup_clones)
-             in
-             sessions >|= CCList.map created >|= CCList.append acc)
+            acc
+            >>= fun acc ->
+            let sessions =
+              let* parent_clone =
+                build_session ?parent:parent_session form_data session
+              in
+              let* followup_clones =
+                let open CCList in
+                followups >|= build_session ~parent:parent_clone form_data |> all_ok
+              in
+              Ok (parent_clone :: followup_clones)
+            in
+            sessions >|= CCList.map created >|= CCList.append acc)
           (Ok [])
   ;;
 
@@ -482,21 +482,21 @@ end = struct
   type t = Session.base
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ?parent_session
-        follow_up_sessions
-        session
-        location
-        (Session.
-           { start
-           ; internal_description
-           ; public_description
-           ; max_participants
-           ; min_participants
-           ; overbook
-           ; _
-           } as command :
-          Session.base)
+    ?(tags = Logs.Tag.empty)
+    ?parent_session
+    follow_up_sessions
+    session
+    location
+    (Session.
+       { start
+       ; internal_description
+       ; public_description
+       ; max_participants
+       ; min_participants
+       ; overbook
+       ; _
+       } as command :
+      Session.base)
     =
     Logs.info ~src (fun m -> m "Handle command Update" ~tags);
     let open Session in
@@ -580,13 +580,13 @@ end = struct
   ;;
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        ?parent_session
-        follow_up_sessions
-        session
-        assignments
-        create_message
-        ({ start; duration; duration_unit } : t)
+    ?(tags = Logs.Tag.empty)
+    ?parent_session
+    follow_up_sessions
+    session
+    assignments
+    create_message
+    ({ start; duration; duration_unit } : t)
     =
     Logs.info ~src (fun m -> m "Handle command Reschedule" ~tags);
     let open CCResult in
@@ -605,10 +605,7 @@ end = struct
     in
     Ok
       ((Session.Rescheduled (session, { Session.start; duration }) |> Pool_event.session)
-       ::
-       (if emails |> CCList.is_empty |> not
-        then [ Email.BulkSent emails |> Pool_event.email ]
-        else []))
+       :: (Email.bulksent_opt emails |> Pool_event.(map email)))
   ;;
 
   let decode data =
@@ -675,13 +672,13 @@ end = struct
   type t = Session.CancellationReason.t
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        sessions
-        (assignments : (Contact.t * Assignment.t list) list)
-        email_fn
-        text_message_fn
-        notify_via
-        (reason : t)
+    ?(tags = Logs.Tag.empty)
+    sessions
+    (assignments : (Contact.t * Assignment.t list) list)
+    email_fn
+    text_message_fn
+    notify_via
+    (reason : t)
     =
     Logs.info ~src (fun m -> m "Handle command Cancel" ~tags);
     let open CCResult in
@@ -766,11 +763,11 @@ end = struct
       list
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        experiment
-        (session : Session.t)
-        (participation_tags : Tags.t list)
-        (command : t)
+    ?(tags = Logs.Tag.empty)
+    experiment
+    (session : Session.t)
+    (participation_tags : Tags.t list)
+    (command : t)
     =
     Logs.info ~src (fun m -> m "Handle command SetAttendance" ~tags);
     let open CCResult in
@@ -779,73 +776,73 @@ end = struct
     let* () = Session.is_closable session in
     CCList.fold_left
       (fun events participation ->
-         events
-         >>= fun events ->
-         participation
-         |> fun ( ({ contact; _ } as assignment : Assignment.t)
-                , increment_num_participaton
-                , follow_ups ) ->
-         let updated_assignment, no_show, participated =
-           set_close_default_values assignment
-         in
-         let* () =
-           validate experiment updated_assignment
-           |> CCResult.map_err (CCFun.const Pool_message.Error.AssignmentsHaveErrors)
-         in
-         let cancel_followups =
-           NoShow.value no_show || not (Participated.value participated)
-         in
-         let* () = attendance_settable updated_assignment in
-         let* contact =
-           Contact_counter.update_on_session_closing
-             contact
-             no_show
-             participated
-             increment_num_participaton
-         in
-         let num_assignments_decrement, mark_as_deleted =
-           let open CCList in
-           match cancel_followups, follow_ups with
-           | true, Some follow_ups ->
-             let num_assignments =
-               follow_ups
-               |> filter (fun assignment ->
-                    CCOption.is_none assignment.Assignment.canceled_at)
-                  %> length
-             in
-             let marked_as_deleted =
-               follow_ups >|= markedasdeleted %> Pool_event.assignment
-             in
-             num_assignments, marked_as_deleted
-           | _, _ -> 0, []
-         in
-         let contact =
-           Contact.update_num_assignments
-             ~step:(CCInt.neg num_assignments_decrement)
-             contact
-         in
-         let tag_events =
-           let open Tags in
-           match participated |> Participated.value with
-           | false -> []
-           | true ->
-             participation_tags
-             |> CCList.map (fun (tag : t) ->
-               Tagged
-                 Tagged.
-                   { model_uuid = Contact.id contact |> Contact.Id.to_common
-                   ; tag_uuid = tag.id
-                   }
-               |> Pool_event.tags)
-         in
-         let contact_events =
-           (Contact.Updated contact |> Pool_event.contact) :: mark_as_deleted
-         in
-         events
-         @ ((Assignment.Updated (assignment, updated_assignment) |> Pool_event.assignment)
-            :: contact_events)
-         @ tag_events
-         |> CCResult.return)
+        events
+        >>= fun events ->
+        participation
+        |> fun ( ({ contact; _ } as assignment : Assignment.t)
+               , increment_num_participaton
+               , follow_ups ) ->
+        let updated_assignment, no_show, participated =
+          set_close_default_values assignment
+        in
+        let* () =
+          validate experiment updated_assignment
+          |> CCResult.map_err (CCFun.const Pool_message.Error.AssignmentsHaveErrors)
+        in
+        let cancel_followups =
+          NoShow.value no_show || not (Participated.value participated)
+        in
+        let* () = attendance_settable updated_assignment in
+        let* contact =
+          Contact_counter.update_on_session_closing
+            contact
+            no_show
+            participated
+            increment_num_participaton
+        in
+        let num_assignments_decrement, mark_as_deleted =
+          let open CCList in
+          match cancel_followups, follow_ups with
+          | true, Some follow_ups ->
+            let num_assignments =
+              follow_ups
+              |> filter (fun assignment ->
+                   CCOption.is_none assignment.Assignment.canceled_at)
+                 %> length
+            in
+            let marked_as_deleted =
+              follow_ups >|= markedasdeleted %> Pool_event.assignment
+            in
+            num_assignments, marked_as_deleted
+          | _, _ -> 0, []
+        in
+        let contact =
+          Contact.update_num_assignments
+            ~step:(CCInt.neg num_assignments_decrement)
+            contact
+        in
+        let tag_events =
+          let open Tags in
+          match participated |> Participated.value with
+          | false -> []
+          | true ->
+            participation_tags
+            |> CCList.map (fun (tag : t) ->
+              Tagged
+                Tagged.
+                  { model_uuid = Contact.id contact |> Contact.Id.to_common
+                  ; tag_uuid = tag.id
+                  }
+              |> Pool_event.tags)
+        in
+        let contact_events =
+          (Contact.Updated contact |> Pool_event.contact) :: mark_as_deleted
+        in
+        events
+        @ ((Assignment.Updated (assignment, updated_assignment) |> Pool_event.assignment)
+           :: contact_events)
+        @ tag_events
+        |> CCResult.return)
       (Ok [ Closed session |> Pool_event.session ])
       command
   ;;
@@ -875,11 +872,11 @@ end = struct
   let schema = Conformist.(make Field.[ Pool_common.MessageChannel.schema () ] CCFun.id)
 
   let handle
-        ?(tags = Logs.Tag.empty)
-        (create_email, create_text_message)
-        session
-        assignments
-        channel
+    ?(tags = Logs.Tag.empty)
+    (create_email, create_text_message)
+    session
+    assignments
+    channel
     =
     Logs.info ~src (fun m -> m "Handle command ResendReminders" ~tags);
     let open Pool_common.MessageChannel in
@@ -900,22 +897,20 @@ end = struct
           assignments
           |> CCList.fold_left
                (fun messages ({ Assignment.contact; _ } as assignment) ->
-                  messages
-                  >>= fun (emails, text_messages) ->
-                  match contact.Contact.cell_phone with
-                  | None ->
-                    create_email assignment
-                    >|= fun email -> email :: emails, text_messages
-                  | Some cell_phone ->
-                    create_text_message assignment cell_phone
-                    >|= fun msg -> emails, msg :: text_messages)
+                 messages
+                 >>= fun (emails, text_messages) ->
+                 match contact.Contact.cell_phone with
+                 | None ->
+                   create_email assignment >|= fun email -> email :: emails, text_messages
+                 | Some cell_phone ->
+                   create_text_message assignment cell_phone
+                   >|= fun msg -> emails, msg :: text_messages)
                (Ok ([], []))
         in
         Ok
-          [ Email.BulkSent emails |> Pool_event.email
-          ; Text_message.BulkSent text_messages |> Pool_event.text_message
-          ; Session.TextMsgReminderSent session |> Pool_event.session
-          ]
+          ((Email.bulksent_opt emails |> Pool_event.(map email))
+           @ (Text_message.bulksent_opt text_messages |> Pool_event.(map text_message))
+           @ [ Session.TextMsgReminderSent session |> Pool_event.session ])
     in
     Ok events
   ;;
@@ -1009,9 +1004,8 @@ end = struct
               (make_email_job language email_text email_subject plain_text assignment)
           | None, false -> `Drop)
       in
-      [ Text_message.BulkSent sms_jobs |> Pool_event.text_message
-      ; Email.BulkSent email_jobs |> Pool_event.email
-      ]
+      (Text_message.bulksent_opt sms_jobs |> Pool_event.(map text_message))
+      @ (Email.bulksent_opt email_jobs |> Pool_event.(map email))
   ;;
 
   let email_command language email_subject email_text plain_text =

--- a/pool/cqrs_command/session_command.ml
+++ b/pool/cqrs_command/session_command.ml
@@ -12,18 +12,18 @@ type reschedule =
 let src = Logs.Src.create "session.cqrs"
 
 let command
-  start
-  duration
-  duration_unit
-  internal_description
-  public_description
-  max_participants
-  min_participants
-  overbook
-  email_reminder_lead_time
-  email_reminder_lead_time_unit
-  text_message_reminder_lead_time
-  text_message_reminder_lead_time_unit
+      start
+      duration
+      duration_unit
+      internal_description
+      public_description
+      max_participants
+      min_participants
+      overbook
+      email_reminder_lead_time
+      email_reminder_lead_time_unit
+      text_message_reminder_lead_time
+      text_message_reminder_lead_time_unit
   : Session.base
   =
   Session.
@@ -65,14 +65,14 @@ let schema =
 ;;
 
 let decode_time_durations
-  { Session.duration
-  ; duration_unit
-  ; email_reminder_lead_time
-  ; email_reminder_lead_time_unit
-  ; text_message_reminder_lead_time
-  ; text_message_reminder_lead_time_unit
-  ; _
-  }
+      { Session.duration
+      ; duration_unit
+      ; email_reminder_lead_time
+      ; email_reminder_lead_time_unit
+      ; text_message_reminder_lead_time
+      ; text_message_reminder_lead_time_unit
+      ; _
+      }
   =
   let open CCResult in
   let open Pool_common in
@@ -96,7 +96,7 @@ let starts_after_parent parent_session start =
   CCOption.map_or
     ~default:false
     (fun (s : Session.t) ->
-      Ptime.is_earlier ~than:(Start.value s.start) (Start.value start))
+       Ptime.is_earlier ~than:(Start.value s.start) (Start.value start))
     parent_session
 ;;
 
@@ -106,7 +106,7 @@ let validate_start follow_up_sessions parent_session start =
   let starts_before_followups =
     CCList.exists
       (fun (follow_up : Session.t) ->
-        Ptime.is_earlier ~than:(Start.value start) (Start.value follow_up.start))
+         Ptime.is_earlier ~than:(Start.value start) (Start.value follow_up.start))
       follow_up_sessions
   in
   if starts_after_parent parent_session start || starts_before_followups
@@ -143,21 +143,21 @@ end = struct
   let schema = schema
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ?parent_session
-    ?session_id
-    experiment
-    location
-    (Session.
-       { start
-       ; internal_description
-       ; public_description
-       ; max_participants
-       ; min_participants
-       ; overbook
-       ; _
-       } as command :
-      Session.base)
+        ?(tags = Logs.Tag.empty)
+        ?parent_session
+        ?session_id
+        experiment
+        location
+        (Session.
+           { start
+           ; internal_description
+           ; public_description
+           ; max_participants
+           ; min_participants
+           ; overbook
+           ; _
+           } as command :
+          Session.base)
     =
     Logs.info ~src (fun m -> m "Handle command Create" ~tags);
     let open CCResult in
@@ -200,11 +200,11 @@ end = struct
 end
 
 let time_window_command
-  start
-  end_at
-  internal_description
-  public_description
-  max_participants
+      start
+      end_at
+      internal_description
+      public_description
+      max_participants
   : Time_window.create
   =
   let open Time_window in
@@ -242,16 +242,16 @@ end = struct
   type t = Time_window.create
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ~overlapps
-    ?id
-    experiment
-    { Time_window.start
-    ; end_at
-    ; internal_description
-    ; public_description
-    ; max_participants
-    }
+        ?(tags = Logs.Tag.empty)
+        ~overlapps
+        ?id
+        experiment
+        { Time_window.start
+        ; end_at
+        ; internal_description
+        ; public_description
+        ; max_participants
+        }
     =
     Logs.info ~src (fun m -> m "Handle command CreateTimeWindow" ~tags);
     let open CCResult in
@@ -301,15 +301,15 @@ end = struct
   type t = Time_window.create
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ~overlapps
-    time_window
-    { Time_window.start
-    ; end_at
-    ; internal_description
-    ; public_description
-    ; max_participants
-    }
+        ?(tags = Logs.Tag.empty)
+        ~overlapps
+        time_window
+        { Time_window.start
+        ; end_at
+        ; internal_description
+        ; public_description
+        ; max_participants
+        }
     =
     Logs.info ~src (fun m -> m "Handle command UpdateTimeWindow" ~tags);
     let open CCResult in
@@ -374,23 +374,23 @@ end = struct
     urlencoded
     |> CCList.fold_left
          (fun acc (key, value) ->
-           let open CCString in
-           match acc with
-           | Error _ -> acc
-           | Ok (acc : (int * (Session.Id.t * Session.Start.t) list) list) ->
-             key
-             |> replace ~which:`Right ~sub:"]" ~by:""
-             |> split ~by:"["
-             |> (function
-              | [ id; group ] ->
-                parse_row id group value
-                >|= fun (group, data) ->
-                let eq = CCInt.equal in
-                let current =
-                  CCList.assoc_opt ~eq group acc |> CCOption.value ~default:[]
-                in
-                CCList.Assoc.set ~eq group (data :: current) acc
-              | _ -> Ok acc))
+            let open CCString in
+            match acc with
+            | Error _ -> acc
+            | Ok (acc : (int * (Session.Id.t * Session.Start.t) list) list) ->
+              key
+              |> replace ~which:`Right ~sub:"]" ~by:""
+              |> split ~by:"["
+              |> (function
+               | [ id; group ] ->
+                 parse_row id group value
+                 >|= fun (group, data) ->
+                 let eq = CCInt.equal in
+                 let current =
+                   CCList.assoc_opt ~eq group acc |> CCOption.value ~default:[]
+                 in
+                 CCList.Assoc.set ~eq group (data :: current) acc
+               | _ -> Ok acc))
          (Ok [])
   ;;
 
@@ -398,20 +398,20 @@ end = struct
     let open CCResult in
     Logs.info ~src (fun m -> m "Handle command Duplicate" ~tags);
     let validate_and_merge_session
-      ?parent
-      { Session.internal_description
-      ; public_description
-      ; email_reminder_lead_time
-      ; text_message_reminder_lead_time
-      ; duration
-      ; location
-      ; max_participants
-      ; min_participants
-      ; overbook
-      ; experiment
-      ; _
-      }
-      start
+          ?parent
+          { Session.internal_description
+          ; public_description
+          ; email_reminder_lead_time
+          ; text_message_reminder_lead_time
+          ; duration
+          ; location
+          ; max_participants
+          ; min_participants
+          ; overbook
+          ; experiment
+          ; _
+          }
+          start
       =
       if starts_after_parent parent start
       then Error Pool_message.Error.FollowUpIsEarlierThanMain
@@ -445,19 +445,19 @@ end = struct
     |> parse_urlencoded
     >>= CCList.fold_left
           (fun acc (_, form_data) ->
-            acc
-            >>= fun acc ->
-            let sessions =
-              let* parent_clone =
-                build_session ?parent:parent_session form_data session
-              in
-              let* followup_clones =
-                let open CCList in
-                followups >|= build_session ~parent:parent_clone form_data |> all_ok
-              in
-              Ok (parent_clone :: followup_clones)
-            in
-            sessions >|= CCList.map created >|= CCList.append acc)
+             acc
+             >>= fun acc ->
+             let sessions =
+               let* parent_clone =
+                 build_session ?parent:parent_session form_data session
+               in
+               let* followup_clones =
+                 let open CCList in
+                 followups >|= build_session ~parent:parent_clone form_data |> all_ok
+               in
+               Ok (parent_clone :: followup_clones)
+             in
+             sessions >|= CCList.map created >|= CCList.append acc)
           (Ok [])
   ;;
 
@@ -482,21 +482,21 @@ end = struct
   type t = Session.base
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ?parent_session
-    follow_up_sessions
-    session
-    location
-    (Session.
-       { start
-       ; internal_description
-       ; public_description
-       ; max_participants
-       ; min_participants
-       ; overbook
-       ; _
-       } as command :
-      Session.base)
+        ?(tags = Logs.Tag.empty)
+        ?parent_session
+        follow_up_sessions
+        session
+        location
+        (Session.
+           { start
+           ; internal_description
+           ; public_description
+           ; max_participants
+           ; min_participants
+           ; overbook
+           ; _
+           } as command :
+          Session.base)
     =
     Logs.info ~src (fun m -> m "Handle command Update" ~tags);
     let open Session in
@@ -580,13 +580,13 @@ end = struct
   ;;
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    ?parent_session
-    follow_up_sessions
-    session
-    assignments
-    create_message
-    ({ start; duration; duration_unit } : t)
+        ?(tags = Logs.Tag.empty)
+        ?parent_session
+        follow_up_sessions
+        session
+        assignments
+        create_message
+        ({ start; duration; duration_unit } : t)
     =
     Logs.info ~src (fun m -> m "Handle command Reschedule" ~tags);
     let open CCResult in
@@ -672,13 +672,13 @@ end = struct
   type t = Session.CancellationReason.t
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    sessions
-    (assignments : (Contact.t * Assignment.t list) list)
-    email_fn
-    text_message_fn
-    notify_via
-    (reason : t)
+        ?(tags = Logs.Tag.empty)
+        sessions
+        (assignments : (Contact.t * Assignment.t list) list)
+        email_fn
+        text_message_fn
+        notify_via
+        (reason : t)
     =
     Logs.info ~src (fun m -> m "Handle command Cancel" ~tags);
     let open CCResult in
@@ -763,11 +763,11 @@ end = struct
       list
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    experiment
-    (session : Session.t)
-    (participation_tags : Tags.t list)
-    (command : t)
+        ?(tags = Logs.Tag.empty)
+        experiment
+        (session : Session.t)
+        (participation_tags : Tags.t list)
+        (command : t)
     =
     Logs.info ~src (fun m -> m "Handle command SetAttendance" ~tags);
     let open CCResult in
@@ -776,73 +776,73 @@ end = struct
     let* () = Session.is_closable session in
     CCList.fold_left
       (fun events participation ->
-        events
-        >>= fun events ->
-        participation
-        |> fun ( ({ contact; _ } as assignment : Assignment.t)
-               , increment_num_participaton
-               , follow_ups ) ->
-        let updated_assignment, no_show, participated =
-          set_close_default_values assignment
-        in
-        let* () =
-          validate experiment updated_assignment
-          |> CCResult.map_err (CCFun.const Pool_message.Error.AssignmentsHaveErrors)
-        in
-        let cancel_followups =
-          NoShow.value no_show || not (Participated.value participated)
-        in
-        let* () = attendance_settable updated_assignment in
-        let* contact =
-          Contact_counter.update_on_session_closing
-            contact
-            no_show
-            participated
-            increment_num_participaton
-        in
-        let num_assignments_decrement, mark_as_deleted =
-          let open CCList in
-          match cancel_followups, follow_ups with
-          | true, Some follow_ups ->
-            let num_assignments =
-              follow_ups
-              |> filter (fun assignment ->
-                   CCOption.is_none assignment.Assignment.canceled_at)
-                 %> length
-            in
-            let marked_as_deleted =
-              follow_ups >|= markedasdeleted %> Pool_event.assignment
-            in
-            num_assignments, marked_as_deleted
-          | _, _ -> 0, []
-        in
-        let contact =
-          Contact.update_num_assignments
-            ~step:(CCInt.neg num_assignments_decrement)
-            contact
-        in
-        let tag_events =
-          let open Tags in
-          match participated |> Participated.value with
-          | false -> []
-          | true ->
-            participation_tags
-            |> CCList.map (fun (tag : t) ->
-              Tagged
-                Tagged.
-                  { model_uuid = Contact.id contact |> Contact.Id.to_common
-                  ; tag_uuid = tag.id
-                  }
-              |> Pool_event.tags)
-        in
-        let contact_events =
-          (Contact.Updated contact |> Pool_event.contact) :: mark_as_deleted
-        in
-        events
-        @ ((Assignment.Updated (assignment, updated_assignment) |> Pool_event.assignment)
-           :: contact_events)
-        @ tag_events
-        |> CCResult.return)
+         events
+         >>= fun events ->
+         participation
+         |> fun ( ({ contact; _ } as assignment : Assignment.t)
+                , increment_num_participaton
+                , follow_ups ) ->
+         let updated_assignment, no_show, participated =
+           set_close_default_values assignment
+         in
+         let* () =
+           validate experiment updated_assignment
+           |> CCResult.map_err (CCFun.const Pool_message.Error.AssignmentsHaveErrors)
+         in
+         let cancel_followups =
+           NoShow.value no_show || not (Participated.value participated)
+         in
+         let* () = attendance_settable updated_assignment in
+         let* contact =
+           Contact_counter.update_on_session_closing
+             contact
+             no_show
+             participated
+             increment_num_participaton
+         in
+         let num_assignments_decrement, mark_as_deleted =
+           let open CCList in
+           match cancel_followups, follow_ups with
+           | true, Some follow_ups ->
+             let num_assignments =
+               follow_ups
+               |> filter (fun assignment ->
+                    CCOption.is_none assignment.Assignment.canceled_at)
+                  %> length
+             in
+             let marked_as_deleted =
+               follow_ups >|= markedasdeleted %> Pool_event.assignment
+             in
+             num_assignments, marked_as_deleted
+           | _, _ -> 0, []
+         in
+         let contact =
+           Contact.update_num_assignments
+             ~step:(CCInt.neg num_assignments_decrement)
+             contact
+         in
+         let tag_events =
+           let open Tags in
+           match participated |> Participated.value with
+           | false -> []
+           | true ->
+             participation_tags
+             |> CCList.map (fun (tag : t) ->
+               Tagged
+                 Tagged.
+                   { model_uuid = Contact.id contact |> Contact.Id.to_common
+                   ; tag_uuid = tag.id
+                   }
+               |> Pool_event.tags)
+         in
+         let contact_events =
+           (Contact.Updated contact |> Pool_event.contact) :: mark_as_deleted
+         in
+         events
+         @ ((Assignment.Updated (assignment, updated_assignment) |> Pool_event.assignment)
+            :: contact_events)
+         @ tag_events
+         |> CCResult.return)
       (Ok [ Closed session |> Pool_event.session ])
       command
   ;;
@@ -872,11 +872,11 @@ end = struct
   let schema = Conformist.(make Field.[ Pool_common.MessageChannel.schema () ] CCFun.id)
 
   let handle
-    ?(tags = Logs.Tag.empty)
-    (create_email, create_text_message)
-    session
-    assignments
-    channel
+        ?(tags = Logs.Tag.empty)
+        (create_email, create_text_message)
+        session
+        assignments
+        channel
     =
     Logs.info ~src (fun m -> m "Handle command ResendReminders" ~tags);
     let open Pool_common.MessageChannel in
@@ -897,14 +897,15 @@ end = struct
           assignments
           |> CCList.fold_left
                (fun messages ({ Assignment.contact; _ } as assignment) ->
-                 messages
-                 >>= fun (emails, text_messages) ->
-                 match contact.Contact.cell_phone with
-                 | None ->
-                   create_email assignment >|= fun email -> email :: emails, text_messages
-                 | Some cell_phone ->
-                   create_text_message assignment cell_phone
-                   >|= fun msg -> emails, msg :: text_messages)
+                  messages
+                  >>= fun (emails, text_messages) ->
+                  match contact.Contact.cell_phone with
+                  | None ->
+                    create_email assignment
+                    >|= fun email -> email :: emails, text_messages
+                  | Some cell_phone ->
+                    create_text_message assignment cell_phone
+                    >|= fun msg -> emails, msg :: text_messages)
                (Ok ([], []))
         in
         Ok

--- a/pool/cqrs_command/user_command.ml
+++ b/pool/cqrs_command/user_command.ml
@@ -150,8 +150,7 @@ end = struct
 
   let handle ?(tags = Logs.Tag.empty) ?notification user_id command =
     Logs.info ~src (fun m -> m "Handle command UpdatePassword" ~tags);
-    (* NOTE use 'Pool_user.validate_current_password' in handler before this
-       command. *)
+    (* NOTE use 'Pool_user.validate_current_password' in handler before this command. *)
     let open CCResult in
     let* () =
       Pool_user.Password.validate_confirmation

--- a/pool/database/migration/migration.ml
+++ b/pool/database/migration/migration.ml
@@ -143,8 +143,8 @@ let execute_migration database_label migration =
       else
         Lwt.return (state, Migration_repo.Migration.(steps_to_apply steps (version state)))
     | None ->
-      (* If currently no state exists, an new one will be created. If there are
-         steps to execute, it is dirty *)
+      (* If currently no state exists, an new one will be created. If there are steps to
+         execute, it is dirty *)
       Logs.debug (fun m -> m ~tags "Setting up table for %s" namespace);
       let dirty = CCList.is_empty steps |> not in
       let state = Migration_repo.Migration.create ~namespace ~dirty in

--- a/pool/matcher/matcher.ml
+++ b/pool/matcher/matcher.ml
@@ -118,8 +118,8 @@ let find_contacts_by_mailing pool { Mailing.id; distribution; _ } limit =
 ;;
 
 let calculate_mailing_limits
-  interval
-  (pool_based_mailings : ('a * Mailing.Status.status list) list)
+      interval
+      (pool_based_mailings : ('a * Mailing.Status.status list) list)
   =
   let open CCList in
   let open CCFloat in
@@ -225,14 +225,14 @@ let events_of_mailings =
              contacts
              |> Lwt_list.fold_left_s
                   (fun (invitations, contacts) contact ->
-                    contact
-                    |> Contact.id
-                    |> Invitation.find_by_contact_and_experiment_opt
-                         pool
-                         experiment.Experiment.id
-                    |> Lwt.map (function
-                      | None -> invitations, contacts @ [ contact ]
-                      | Some invitation -> invitations @ [ invitation ], contacts))
+                     contact
+                     |> Contact.id
+                     |> Invitation.find_by_contact_and_experiment_opt
+                          pool
+                          experiment.Experiment.id
+                     |> Lwt.map (function
+                       | None -> invitations, contacts @ [ contact ]
+                       | Some invitation -> invitations @ [ invitation ], contacts))
                   ([], [])
              >|> fun (invitations, contacts) ->
              let* resend_events = resend_existing invitations |> Lwt_result.lift in
@@ -249,23 +249,23 @@ let create_invitation_events interval pools =
   let%lwt pool_based_mailings =
     Lwt_list.map_s
       (fun pool ->
-        Mailing.Status.find_current pool interval
-        >|> Lwt_list.filter_map_s (fun ({ Mailing.Status.mailing; _ } as status) ->
-          let find_experiment { Mailing.id; _ } =
-            Experiment.find_of_mailing pool (id |> Mailing.Id.to_common)
-          in
-          let has_spots = experiment_has_bookable_spots pool in
-          let validate = function
-            | true -> Ok status
-            | false -> Error Pool_message.Error.SessionFullyBooked
-          in
-          mailing
-          |> find_experiment
-          |>> has_spots
-          >== validate
-          >|- Pool_common.Utils.with_log_error ~level:Logs.Warning
-          ||> CCResult.to_opt)
-        ||> fun m -> pool, m)
+         Mailing.Status.find_current pool interval
+         >|> Lwt_list.filter_map_s (fun ({ Mailing.Status.mailing; _ } as status) ->
+           let find_experiment { Mailing.id; _ } =
+             Experiment.find_of_mailing pool (id |> Mailing.Id.to_common)
+           in
+           let has_spots = experiment_has_bookable_spots pool in
+           let validate = function
+             | true -> Ok status
+             | false -> Error Pool_message.Error.SessionFullyBooked
+           in
+           mailing
+           |> find_experiment
+           |>> has_spots
+           >== validate
+           >|- Pool_common.Utils.with_log_error ~level:Logs.Warning
+           ||> CCResult.to_opt)
+         ||> fun m -> pool, m)
       pools
   in
   pool_based_mailings |> calculate_mailing_limits interval |> events_of_mailings

--- a/pool/matcher/matcher.ml
+++ b/pool/matcher/matcher.ml
@@ -118,8 +118,8 @@ let find_contacts_by_mailing pool { Mailing.id; distribution; _ } limit =
 ;;
 
 let calculate_mailing_limits
-      interval
-      (pool_based_mailings : ('a * Mailing.Status.status list) list)
+  interval
+  (pool_based_mailings : ('a * Mailing.Status.status list) list)
   =
   let open CCList in
   let open CCFloat in
@@ -163,14 +163,13 @@ let notify_all_invited pool tenant experiment =
              tenant
              Pool_common.Language.En
              experiment)
-      ||> Email.bulksent
-      ||> Pool_event.email
+      ||> Email.bulksent_opt %> Pool_event.(map email)
     in
     let updated =
       { experiment with matcher_notification_sent = MatcherNotificationSent.create true }
     in
     let experiment_event = Updated (experiment, updated) |> Pool_event.experiment in
-    Lwt.return [ email_event; experiment_event ]
+    Lwt.return (experiment_event :: email_event)
 ;;
 
 let events_of_mailings =
@@ -226,14 +225,14 @@ let events_of_mailings =
              contacts
              |> Lwt_list.fold_left_s
                   (fun (invitations, contacts) contact ->
-                     contact
-                     |> Contact.id
-                     |> Invitation.find_by_contact_and_experiment_opt
-                          pool
-                          experiment.Experiment.id
-                     |> Lwt.map (function
-                       | None -> invitations, contacts @ [ contact ]
-                       | Some invitation -> invitations @ [ invitation ], contacts))
+                    contact
+                    |> Contact.id
+                    |> Invitation.find_by_contact_and_experiment_opt
+                         pool
+                         experiment.Experiment.id
+                    |> Lwt.map (function
+                      | None -> invitations, contacts @ [ contact ]
+                      | Some invitation -> invitations @ [ invitation ], contacts))
                   ([], [])
              >|> fun (invitations, contacts) ->
              let* resend_events = resend_existing invitations |> Lwt_result.lift in
@@ -250,23 +249,23 @@ let create_invitation_events interval pools =
   let%lwt pool_based_mailings =
     Lwt_list.map_s
       (fun pool ->
-         Mailing.Status.find_current pool interval
-         >|> Lwt_list.filter_map_s (fun ({ Mailing.Status.mailing; _ } as status) ->
-           let find_experiment { Mailing.id; _ } =
-             Experiment.find_of_mailing pool (id |> Mailing.Id.to_common)
-           in
-           let has_spots = experiment_has_bookable_spots pool in
-           let validate = function
-             | true -> Ok status
-             | false -> Error Pool_message.Error.SessionFullyBooked
-           in
-           mailing
-           |> find_experiment
-           |>> has_spots
-           >== validate
-           >|- Pool_common.Utils.with_log_error ~level:Logs.Warning
-           ||> CCResult.to_opt)
-         ||> fun m -> pool, m)
+        Mailing.Status.find_current pool interval
+        >|> Lwt_list.filter_map_s (fun ({ Mailing.Status.mailing; _ } as status) ->
+          let find_experiment { Mailing.id; _ } =
+            Experiment.find_of_mailing pool (id |> Mailing.Id.to_common)
+          in
+          let has_spots = experiment_has_bookable_spots pool in
+          let validate = function
+            | true -> Ok status
+            | false -> Error Pool_message.Error.SessionFullyBooked
+          in
+          mailing
+          |> find_experiment
+          |>> has_spots
+          >== validate
+          >|- Pool_common.Utils.with_log_error ~level:Logs.Warning
+          ||> CCResult.to_opt)
+        ||> fun m -> pool, m)
       pools
   in
   pool_based_mailings |> calculate_mailing_limits interval |> events_of_mailings

--- a/pool/pool_event/pool_event.ml
+++ b/pool/pool_event/pool_event.ml
@@ -192,3 +192,4 @@ let handle_events ?tags pool user events =
 
 let handle_system_event ?tags pool event = handle ?tags pool event
 let handle_system_events ?tags pool = Lwt_list.iter_s (handle ?tags pool)
+let map = CCList.map

--- a/pool/pool_event/pool_event.mli
+++ b/pool/pool_event/pool_event.mli
@@ -82,3 +82,4 @@ val handle_events
 
 val handle_system_event : ?tags:Logs.Tag.set -> Database.Label.t -> t -> unit Lwt.t
 val handle_system_events : ?tags:Logs.Tag.set -> Database.Label.t -> t list -> unit Lwt.t
+val map : ('a -> t) -> 'a list -> t list

--- a/pool/pool_queue/repo.ml
+++ b/pool/pool_queue/repo.ml
@@ -2,8 +2,8 @@ open Caqti_request.Infix
 open Utils.Lwt_result.Infix
 module Dynparam = Database.Dynparam
 
-(* MariaDB expects uuid to be bytes, since we can't unhex when using caqti's
-   populate, we have to do that manually. *)
+(* MariaDB expects uuid to be bytes, since we can't unhex when using caqti's populate, we
+   have to do that manually. *)
 let to_bytes encode decode id =
   match id |> decode |> Uuidm.of_string with
   | Some uuid -> Uuidm.to_binary_string uuid |> encode

--- a/pool/test/admin_role_assignment.ml
+++ b/pool/test/admin_role_assignment.ml
@@ -123,8 +123,7 @@ let assignable_roles _ () =
     >|> target_has_role db target role
     ||> Alcotest.(check bool) (role_message msg role) should_success
   in
-  (* As the assignable role isn't created yet, the first validation should
-     fail *)
+  (* As the assignable role isn't created yet, the first validation should fail *)
   let%lwt () = validate_role_assignment targetOne false in
   (* Add the role assignment to the database *)
   let%lwt () =

--- a/pool/test/assignment_job_test.ml
+++ b/pool/test/assignment_job_test.ml
@@ -49,7 +49,7 @@ let to_events (assignment_events, emails) =
   let assignments = CCList.map Pool_event.assignment assignment_events in
   match emails with
   | [] -> assignments
-  | emails -> assignments @ [ Pool_event.email (Email.BulkSent emails) ]
+  | emails -> assignments @ (Email.bulksent_opt emails |> Pool_event.(map email))
 ;;
 
 let update_without_filter _ () =

--- a/pool/test/assignment_job_test.ml
+++ b/pool/test/assignment_job_test.ml
@@ -46,10 +46,8 @@ let init _ () =
 ;;
 
 let to_events (assignment_events, emails) =
-  let assignments = CCList.map Pool_event.assignment assignment_events in
-  match emails with
-  | [] -> assignments
-  | emails -> assignments @ (Email.bulksent_opt emails |> Pool_event.(map email))
+  Pool_event.(map assignment) assignment_events
+  @ (Email.bulksent_opt emails |> Pool_event.(map email))
 ;;
 
 let update_without_filter _ () =

--- a/pool/test/assignment_test.ml
+++ b/pool/test/assignment_test.ml
@@ -735,7 +735,7 @@ let swap_session_without_notification () =
       [ MarkedAsDeleted assignment
       ; Created ({ assignment with id = assignment_id }, new_session.Session.id)
       ]
-    |> CCList.map Pool_event.assignment
+    |> Pool_event.(map assignment)
     |> CCResult.return
   in
   check_result expected result
@@ -777,7 +777,7 @@ let swap_session_to_past_session () =
       [ MarkedAsDeleted assignment
       ; Created ({ assignment with id = assignment_id }, new_session.Session.id)
       ]
-    |> CCList.map Pool_event.assignment
+    |> Pool_event.(map assignment)
     |> CCResult.return
   in
   check_result expected result

--- a/pool/test/custom_field_test.ml
+++ b/pool/test/custom_field_test.ml
@@ -573,7 +573,7 @@ module Settings = struct
       let inactive =
         [ Updated (field1, field1 |> set_show_on_session_close_page false) ]
       in
-      active @ inactive |> CCList.map Pool_event.custom_field |> CCResult.return
+      active @ inactive |> Pool_event.(map custom_field) |> CCResult.return
     in
     let result =
       Cqrs_command.Custom_field_settings_command.UpdateVisibilitySettings.handle

--- a/pool/test/experiment_test.ml
+++ b/pool/test/experiment_test.ml
@@ -442,8 +442,7 @@ module AvailableExperiments = struct
       Integration_utils.AssignmentRepo.create session contact
     in
     let%lwt experiment_not_available =
-      (* Expect the experiment not to be found after registration for a
-         session *)
+      (* Expect the experiment not to be found after registration for a session *)
       let open Experiment in
       find_upcoming_to_register database_label contact `OnSite
       ||> CCList.find_opt (fun public -> Id.equal (Public.id public) experiment.id)
@@ -474,8 +473,8 @@ module AvailableExperiments = struct
       |> Pool_event.handle_event database_label current_user
     in
     let find_available_experiment () =
-      (* Expect the experiment not to be found after session cancellation as
-         there is no upcoming uncanceled session *)
+      (* Expect the experiment not to be found after session cancellation as there is no
+         upcoming uncanceled session *)
       let open Experiment in
       find_upcoming_to_register database_label contact `OnSite
       ||> CCList.find_opt (Public.id %> Id.equal experiment_id)
@@ -484,8 +483,8 @@ module AvailableExperiments = struct
     let%lwt experiment_available = find_available_experiment () in
     let () = Alcotest.(check bool "not listed as available" false experiment_available) in
     let%lwt upcoming_session_found =
-      (* Expect the session to be listed among the upcoming sessions, but to be
-         marked as canceled *)
+      (* Expect the session to be listed among the upcoming sessions, but to be marked as
+         canceled *)
       Session.find_upcoming_public_by_contact database_label (Contact.id contact)
       ||> get_exn
       ||> CCList.find_opt (fun (_, upcoming, _) ->
@@ -495,8 +494,7 @@ module AvailableExperiments = struct
       ||> CCOption.is_some
     in
     let () = Alcotest.(check bool "canceled session found" true upcoming_session_found) in
-    (* Expect the experiment to be listed as available, as an upcoming session
-       exists *)
+    (* Expect the experiment to be listed as available, as an upcoming session exists *)
     let%lwt (_ : Session.t) = Integration_utils.SessionRepo.create experiment () in
     let%lwt experiment_available = find_available_experiment () in
     let () = Alcotest.(check bool "listed as available" true experiment_available) in
@@ -516,16 +514,14 @@ module AvailableExperiments = struct
       >|> Pool_event.handle_events database_label current_user
     in
     let%lwt experiment_available =
-      (* Expect the experiment not to be found after marking the assignment as
-         deleted *)
+      (* Expect the experiment not to be found after marking the assignment as deleted *)
       let open Experiment in
       find_upcoming_to_register database_label contact `OnSite
       ||> CCList.find_opt (Public.id %> Id.equal experiment_id)
       ||> CCOption.is_some
     in
     let%lwt upcoming_session_not_found =
-      (* Expect the session not to be listed, as the assignments are marked as
-         deleted *)
+      (* Expect the session not to be listed, as the assignments are marked as deleted *)
       Session.find_upcoming_public_by_contact database_label (Contact.id contact)
       ||> get_exn
       ||> CCList.find_opt (fun (_, upcoming, _) ->

--- a/pool/test/filter_assignment_tests.ml
+++ b/pool/test/filter_assignment_tests.ml
@@ -217,11 +217,10 @@ let finds_unassigned_contacts =
   let& found_contacts =
     Filter.find_filtered_contacts test_db Filter.MatchesFilter (Some assignment_filter)
   in
-  (* FIXME(@leostera): since tests are not currently running in isolation, when
-     we search for things we may find a lot more than we care about. This little
-     filtering makes sure that we only ever return some of the users that we
-     have created. This is a HACK and we shoudl fix it by ensuring every test is
-     run in its own transaction. *)
+  (* FIXME(@leostera): since tests are not currently running in isolation, when we search
+     for things we may find a lot more than we care about. This little filtering makes
+     sure that we only ever return some of the users that we have created. This is a HACK
+     and we shoudl fix it by ensuring every test is run in its own transaction. *)
   let found_contacts =
     CCList.filter
       (fun contact ->
@@ -283,11 +282,10 @@ let filters_out_assigned_contacts =
   let& found_contacts =
     Filter.find_filtered_contacts test_db Filter.MatchesFilter (Some assignment_filter)
   in
-  (* FIXME(@leostera): since tests are not currently running in isolation, when
-     we search for things we may find a lot more than we care about. This little
-     filtering makes sure that we only ever return some of the users that we
-     have created. This is a HACK and we shoudl fix it by ensuring every test is
-     run in its own transaction. *)
+  (* FIXME(@leostera): since tests are not currently running in isolation, when we search
+     for things we may find a lot more than we care about. This little filtering makes
+     sure that we only ever return some of the users that we have created. This is a HACK
+     and we shoudl fix it by ensuring every test is run in its own transaction. *)
   let found_contacts =
     CCList.filter
       (fun contact ->

--- a/pool/test/filter_invitation_tests.ml
+++ b/pool/test/filter_invitation_tests.ml
@@ -153,11 +153,10 @@ let finds_uninvited_contacts =
   let& found_contacts =
     Filter.find_filtered_contacts test_db Filter.MatchesFilter (Some invitation_filter)
   in
-  (* FIXME(@leostera): since tests are not currently running in isolation, when
-     we search for things we may find a lot more than we care about. This little
-     filtering makes sure that we only ever return some of the users that we
-     have created. This is a HACK and we shoudl fix it by ensuring every test is
-     run in its own transaction. *)
+  (* FIXME(@leostera): since tests are not currently running in isolation, when we search
+     for things we may find a lot more than we care about. This little filtering makes
+     sure that we only ever return some of the users that we have created. This is a HACK
+     and we shoudl fix it by ensuring every test is run in its own transaction. *)
   let found_contacts =
     CCList.filter
       (fun contact ->
@@ -214,11 +213,10 @@ let filters_out_invited_contacts =
   let& found_contacts =
     Filter.find_filtered_contacts test_db Filter.MatchesFilter (Some invitation_filter)
   in
-  (* FIXME(@leostera): since tests are not currently running in isolation, when
-     we search for things we may find a lot more than we care about. This little
-     filtering makes sure that we only ever return some of the users that we
-     have created. This is a HACK and we shoudl fix it by ensuring every test is
-     run in its own transaction. *)
+  (* FIXME(@leostera): since tests are not currently running in isolation, when we search
+     for things we may find a lot more than we care about. This little filtering makes
+     sure that we only ever return some of the users that we have created. This is a HACK
+     and we shoudl fix it by ensuring every test is run in its own transaction. *)
   let found_contacts =
     CCList.filter
       (fun contact ->

--- a/pool/test/filter_test.ml
+++ b/pool/test/filter_test.ml
@@ -503,7 +503,6 @@ let update_filter _ () =
     Ok
       [ Experiment.updated experiment updated_experiment |> Pool_event.experiment
       ; Filter.Updated (filter, filter) |> Pool_event.filter
-      ; Email.BulkSent [] |> Pool_event.email
       ]
   in
   check_result expected events |> Lwt.return

--- a/pool/test/filter_test.ml
+++ b/pool/test/filter_test.ml
@@ -105,10 +105,10 @@ module CustomFieldData = struct
     let save_answers ~answer_value ?admin contacts =
       CCList.map
         (fun contact ->
-           let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-           Custom_field.AnswerUpserted
-             (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
-           |> Pool_event.custom_field)
+          let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+          Custom_field.AnswerUpserted
+            (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
+          |> Pool_event.custom_field)
         contacts
     ;;
   end
@@ -145,10 +145,10 @@ module CustomFieldData = struct
     let save_answers ~answer_value ?admin contacts =
       CCList.map
         (fun contact ->
-           let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-           Custom_field.AnswerUpserted
-             (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
-           |> Pool_event.custom_field)
+          let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+          Custom_field.AnswerUpserted
+            (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
+          |> Pool_event.custom_field)
         contacts
     ;;
 
@@ -216,10 +216,10 @@ module CustomFieldData = struct
     let save_answer answer ?admin contacts =
       CCList.map
         (fun contact ->
-           let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-           Custom_field.AnswerUpserted
-             (public (CCOption.is_some admin) answer, Contact.id contact, user)
-           |> Pool_event.custom_field)
+          let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+          Custom_field.AnswerUpserted
+            (public (CCOption.is_some admin) answer, Contact.id contact, user)
+          |> Pool_event.custom_field)
         contacts
     ;;
 
@@ -268,9 +268,9 @@ module CustomFieldData = struct
   ;;
 
   let admin_override_nr_field_public
-        ?(entity_uuid = Pool_common.Id.create ())
-        is_admin
-        answer_value
+    ?(entity_uuid = Pool_common.Id.create ())
+    is_admin
+    answer_value
     =
     let open Custom_field in
     let answer =
@@ -300,12 +300,12 @@ module CustomFieldData = struct
   let answer_admin_override_nr_field ?admin ~answer_value contacts =
     CCList.map
       (fun contact ->
-         let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-         Custom_field.AnswerUpserted
-           ( admin_override_nr_field_public (CCOption.is_some admin) answer_value
-           , Contact.id contact
-           , user )
-         |> Pool_event.custom_field)
+        let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+        Custom_field.AnswerUpserted
+          ( admin_override_nr_field_public (CCOption.is_some admin) answer_value
+          , Contact.id contact
+          , user )
+        |> Pool_event.custom_field)
       contacts
   ;;
 
@@ -361,8 +361,8 @@ module CustomFieldData = struct
   ;;
 
   let multi_select_custom_field_public
-        ?(entity_uuid = Pool_common.Id.create ())
-        answer_index
+    ?(entity_uuid = Pool_common.Id.create ())
+    answer_index
     =
     let open Custom_field in
     let open Custom_field_test in
@@ -394,17 +394,17 @@ module CustomFieldData = struct
       (Created multi_select_custom_field)
       (multi_select_options
        |> CCList.map (fun o -> OptionCreated (id multi_select_custom_field, o)))
-    |> CCList.map Pool_event.custom_field
+    |> Pool_event.(map custom_field)
   ;;
 
   let answer_multi_select contacts answer_index =
     CCList.map
       (fun contact ->
-         Custom_field.AnswerUpserted
-           ( multi_select_custom_field_public answer_index
-           , Contact.id contact
-           , Pool_context.Contact contact )
-         |> Pool_event.custom_field)
+        Custom_field.AnswerUpserted
+          ( multi_select_custom_field_public answer_index
+          , Contact.id contact
+          , Pool_context.Contact contact )
+        |> Pool_event.custom_field)
       contacts
   ;;
 

--- a/pool/test/filter_test.ml
+++ b/pool/test/filter_test.ml
@@ -105,10 +105,10 @@ module CustomFieldData = struct
     let save_answers ~answer_value ?admin contacts =
       CCList.map
         (fun contact ->
-          let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-          Custom_field.AnswerUpserted
-            (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
-          |> Pool_event.custom_field)
+           let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+           Custom_field.AnswerUpserted
+             (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
+           |> Pool_event.custom_field)
         contacts
     ;;
   end
@@ -145,10 +145,10 @@ module CustomFieldData = struct
     let save_answers ~answer_value ?admin contacts =
       CCList.map
         (fun contact ->
-          let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-          Custom_field.AnswerUpserted
-            (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
-          |> Pool_event.custom_field)
+           let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+           Custom_field.AnswerUpserted
+             (public (CCOption.is_some admin) answer_value, Contact.id contact, user)
+           |> Pool_event.custom_field)
         contacts
     ;;
 
@@ -216,10 +216,10 @@ module CustomFieldData = struct
     let save_answer answer ?admin contacts =
       CCList.map
         (fun contact ->
-          let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-          Custom_field.AnswerUpserted
-            (public (CCOption.is_some admin) answer, Contact.id contact, user)
-          |> Pool_event.custom_field)
+           let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+           Custom_field.AnswerUpserted
+             (public (CCOption.is_some admin) answer, Contact.id contact, user)
+           |> Pool_event.custom_field)
         contacts
     ;;
 
@@ -268,9 +268,9 @@ module CustomFieldData = struct
   ;;
 
   let admin_override_nr_field_public
-    ?(entity_uuid = Pool_common.Id.create ())
-    is_admin
-    answer_value
+        ?(entity_uuid = Pool_common.Id.create ())
+        is_admin
+        answer_value
     =
     let open Custom_field in
     let answer =
@@ -300,12 +300,12 @@ module CustomFieldData = struct
   let answer_admin_override_nr_field ?admin ~answer_value contacts =
     CCList.map
       (fun contact ->
-        let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
-        Custom_field.AnswerUpserted
-          ( admin_override_nr_field_public (CCOption.is_some admin) answer_value
-          , Contact.id contact
-          , user )
-        |> Pool_event.custom_field)
+         let user = admin |> CCOption.value ~default:(Pool_context.Contact contact) in
+         Custom_field.AnswerUpserted
+           ( admin_override_nr_field_public (CCOption.is_some admin) answer_value
+           , Contact.id contact
+           , user )
+         |> Pool_event.custom_field)
       contacts
   ;;
 
@@ -361,8 +361,8 @@ module CustomFieldData = struct
   ;;
 
   let multi_select_custom_field_public
-    ?(entity_uuid = Pool_common.Id.create ())
-    answer_index
+        ?(entity_uuid = Pool_common.Id.create ())
+        answer_index
     =
     let open Custom_field in
     let open Custom_field_test in
@@ -400,11 +400,11 @@ module CustomFieldData = struct
   let answer_multi_select contacts answer_index =
     CCList.map
       (fun contact ->
-        Custom_field.AnswerUpserted
-          ( multi_select_custom_field_public answer_index
-          , Contact.id contact
-          , Pool_context.Contact contact )
-        |> Pool_event.custom_field)
+         Custom_field.AnswerUpserted
+           ( multi_select_custom_field_public answer_index
+           , Contact.id contact
+           , Pool_context.Contact contact )
+         |> Pool_event.custom_field)
       contacts
   ;;
 

--- a/pool/test/integration_utils.ml
+++ b/pool/test/integration_utils.ml
@@ -67,7 +67,7 @@ module ContactRepo = struct
           }
       ]
       @ confirm
-      |> CCList.map Pool_event.contact
+      |> Pool_event.(map contact)
       |> Pool_event.handle_events Data.database_label current_user
     in
     contact |> id |> find Data.database_label ||> get_or_failwith

--- a/pool/test/integration_utils.ml
+++ b/pool/test/integration_utils.ml
@@ -147,8 +147,8 @@ module MailingRepo = struct
 end
 
 module WaitingListRepo = struct
-  (* TODO: Is there a case where admins create waiting list entries? Or will it
-     always be the contact *)
+  (* TODO: Is there a case where admins create waiting list entries? Or will it always be
+     the contact *)
   let create experiment contact () =
     let%lwt () =
       Waiting_list.Created { Waiting_list.experiment; contact }

--- a/pool/test/mailing_test.ml
+++ b/pool/test/mailing_test.ml
@@ -170,7 +170,7 @@ let create_with_start_now () =
     Mailing.create start_at end_at limit distribution)
     |> CCResult.is_ok
   in
-  (* Only testing if mailing is Ok, as comparison of timestampts with
-     Ptime_clock.now () fails *)
+  (* Only testing if mailing is Ok, as comparison of timestampts with Ptime_clock.now ()
+     fails *)
   Alcotest.(check bool "succeeds" true res)
 ;;

--- a/pool/test/matcher_test.ml
+++ b/pool/test/matcher_test.ml
@@ -319,7 +319,7 @@ let matcher_notification _ () =
     in
     let experiment = Experiment.Updated (experiment, updated) |> Pool_event.experiment in
     let%lwt emails = email_event () in
-    Lwt.return [ emails; experiment ]
+    Lwt.return [ experiment; emails ]
   in
   (* Expect notification to be sent *)
   let () = Alcotest.(check (list Test_utils.event) "succeeds" expected events) in

--- a/pool/test/message_template_test.ml
+++ b/pool/test/message_template_test.ml
@@ -162,8 +162,8 @@ let get_template_without_experiment_language_and_templates _ () =
   let%lwt default_template_en = find_default_by_label_and_language en label in
   let%lwt res_de = find_template contact_de in
   let%lwt res_en = find_template contact_en in
-  (* As no experiment language is defined, always expect a template in the
-     contat language to be returned *)
+  (* As no experiment language is defined, always expect a template in the contat language
+     to be returned *)
   check_template default_template_de res_de;
   check_template default_template_en res_en;
   Lwt.return_unit
@@ -232,8 +232,7 @@ let get_template_with_language_missing _ () =
               ~entity_uuids:Experiment.[ experiment.id |> Id.to_common ]
               label)
     in
-    (* When one entity specific template exists, expect this to be returned
-       every time *)
+    (* When one entity specific template exists, expect this to be returned every time *)
     let expected = [ template; template ] in
     Alcotest.(check (list Test_utils.message_template) "succeeds" expected res)
     |> Lwt.return

--- a/pool/test/role_permission_test.ml
+++ b/pool/test/role_permission_test.ml
@@ -43,7 +43,7 @@ let update_permissions () =
       [ RolePermissionSaved [ role_permission Permission.Delete ]
       ; RolePermissionDeleted (role_permission Permission.Update)
       ]
-    |> CCList.map Pool_event.guard
+    |> Pool_event.(map guard)
     |> return
   in
   Test_utils.check_result expected events

--- a/pool/test/session_test.ml
+++ b/pool/test/session_test.ml
@@ -1590,8 +1590,8 @@ module Duplication = struct
   let equal_session (a : t) (b : t) =
     let open Session in
     let open Pool_common.Reminder in
-    (* The ID's are generated in the command handle function, therefore we do
-       not compare the ids but check wheater 'follow_up_to is set or not' *)
+    (* The ID's are generated in the command handle function, therefore we do not compare
+       the ids but check wheater 'follow_up_to is set or not' *)
     let equal_id _ _ = true in
     let amount_equal = ParticipantAmount.equal in
     CCOption.equal equal_id a.follow_up_to b.follow_up_to

--- a/pool/test/session_test.ml
+++ b/pool/test/session_test.ml
@@ -1858,7 +1858,6 @@ module DirectMessaging = struct
       Ok
         [ Text_message.BulkSent [ Model.create_text_message_job cell_phone ]
           |> Pool_event.text_message
-        ; Email.BulkSent [] |> Pool_event.email
         ]
     in
     check_result expected res

--- a/pool/test/test_utils.ml
+++ b/pool/test/test_utils.ml
@@ -551,10 +551,10 @@ module Repo = struct
   ;;
 
   (* TODO: This belongs to the intergration utils *)
-  (* let create_experiment ?(id = Experiment.Id.create ()) ?filter () = let
-     experiment = Model.create_experiment ~id ?filter () in let%lwt () =
-     Experiment.Created experiment |> Pool_event.experiment |>
-     Pool_event.handle_event Data.database_label in Lwt.return experiment ;; *)
+  (* let create_experiment ?(id = Experiment.Id.create ()) ?filter () = let experiment =
+     Model.create_experiment ~id ?filter () in let%lwt () = Experiment.Created experiment
+     |> Pool_event.experiment |> Pool_event.handle_event Data.database_label in Lwt.return
+     experiment ;; *)
 
   let first_location () =
     let open Utils.Lwt_result.Infix in

--- a/pool/web/handler/public_import.ml
+++ b/pool/web/handler/public_import.ml
@@ -88,8 +88,7 @@ let import_confirmation_post req =
       |> Lwt_result.lift
       >|- fun err -> err, error_path (Some token)
     in
-    (* TODO: This takes the imported user as argument, but there is no logged in
-       user *)
+    (* TODO: This takes the imported user as argument, but there is no logged in user *)
     let%lwt () = Pool_event.handle_events ~tags database_label user events in
     Http_utils.(
       redirect_to_with_actions

--- a/pool/web/middleware/middleware_error.ml
+++ b/pool/web/middleware/middleware_error.ml
@@ -114,9 +114,8 @@ let middleware ?error_handler () =
             (* Default to text/html *)
             | Some _ | None -> site_error_handler req))
   in
-  (* In a production setting we don't want to use the built in debugger
-     middleware of opium. It is useful for development but it exposed too much
-     information. *)
+  (* In a production setting we don't want to use the built in debugger middleware of
+     opium. It is useful for development but it exposed too much information. *)
   if Sihl.Configuration.is_production ()
   then Rock.Middleware.create ~name:"error" ~filter
   else Opium.Middleware.debugger

--- a/pool/web/middleware/middleware_tenant.ml
+++ b/pool/web/middleware/middleware_tenant.ml
@@ -5,8 +5,8 @@ let src = Logs.Src.create "middleware.tenant"
 
 let tenant_url_of_request =
   let open CCFun in
-  (* TODO handle PREFIX_PATH of Tenant URLs, multiple tenants behind the same
-     host cannot be handled at the moment *)
+  (* TODO handle PREFIX_PATH of Tenant URLs, multiple tenants behind the same host cannot
+     be handled at the moment *)
   Sihl.Web.Request.header "host"
   %> CCOption.to_result Pool_message.(Error.NotFound Field.Host)
   %> flip CCResult.( >>= ) Pool_tenant.Url.create

--- a/pool/web/view/component/component_changelog.ml
+++ b/pool/web/view/component/component_changelog.ml
@@ -61,8 +61,7 @@ let list Pool_context.{ language; _ } url changelog =
     in
     let th_class = [ "w-3"; "w-7"; "w-2" ] in
     let row ({ user; changes; created_at; _ } : t) =
-      (* TODO: differ between admins and users, maybe create a route that
-         redirects *)
+      (* TODO: differ between admins and users, maybe create a route that redirects *)
       let user_link =
         match user with
         | None -> txt ""

--- a/pool/web/view/component/component_input.ml
+++ b/pool/web/view/component/component_input.ml
@@ -474,8 +474,7 @@ let textarea_element
   let textarea_attributes =
     let base = [ a_name (name |> Field.show); a_id id ] in
     let base = if rich_text then a_class [ "rich-text" ] :: base else base in
-    (* Chrome has problems with CKEditor, when field is required and initially
-       empty *)
+    (* Chrome has problems with CKEditor, when field is required and initially empty *)
     match rich_text, required, CCString.(trim value |> length) > 0 with
     | false, true, _ | true, true, true -> base @ [ a_required () ]
     | true, _, _ | _, false, _ -> base

--- a/pool/web/view/page/page_admin_mailings.ml
+++ b/pool/web/view/page/page_admin_mailings.ml
@@ -580,8 +580,7 @@ let form
                  ]
              ; distribution_select
                  (CCOption.bind mailing (fun (m : Mailing.t) -> m.Mailing.distribution))
-               (* TODO: Add detailed description how distribution element
-                  works *)
+               (* TODO: Add detailed description how distribution element works *)
              ; div
                  ~a:[ a_class [ "flexrow" ] ]
                  [ submit_element ~classnames:[ "push" ] language submit () ]

--- a/pool/web/view/page/page_admin_session.ml
+++ b/pool/web/view/page/page_admin_session.ml
@@ -208,9 +208,9 @@ let session_form
     session |> CCOption.map_or ~default:false (fun s -> s |> Session.has_assignments)
   in
   let default_value_session =
-    (* Prefill the form with values if making a duplicate, editing a session or
-       creating a follow up to a parent. The importance is 1. duplicate, 2.
-       session editing, 3. follow_up_to *)
+    (* Prefill the form with values if making a duplicate, editing a session or creating a
+       follow up to a parent. The importance is 1. duplicate, 2. session editing, 3.
+       follow_up_to *)
     CCOption.(duplicate_parent <+> session <+> follow_up_to)
   in
   let reschedule_hint () =
@@ -282,8 +282,7 @@ let session_form
     ; div
         ~a:[ a_class [ "grid-col-2" ] ]
         [ (let value =
-             (* Don't want start date filled out in form if creating follow
-                up *)
+             (* Don't want start date filled out in form if creating follow up *)
              if CCOption.is_some follow_up_to
              then None
              else
@@ -1457,8 +1456,8 @@ module CloseScreen = struct
       else []
     in
     let value =
-      (* If the field is disabled, add its id as the value to include it in the
-         htmx request *)
+      (* If the field is disabled, add its id as the value to include it in the htmx
+         request *)
       match id_value && disabled with
       | true -> [ a_value (Id.value assignment.id) ]
       | false -> []


### PR DESCRIPTION
- don't create a bulk sent event when the provided list is empty
- in case is empty list, directly return unit
- use newly added `Pool_event.map` when lists are converted to events