### PR TITLE
fix test email send route in route

### DIFF
--- a/pool/app/email/email_service.ml
+++ b/pool/app/email/email_service.ml
@@ -304,7 +304,6 @@ let test_smtp_config database_label config test_email_address =
   let%lwt { sender; reply_to; recipients; subject; body; config } =
     prepare_test_email database_label config test_email_address
   in
-  print_endline "Testing SMTP configuration";
   let send_mail () =
     let message =
       Letters.create_email ~reply_to ~from:sender ~recipients ~subject ~body ()


### PR DESCRIPTION
SMTP password is not logged when updating SMTP settings or tenant. But sending a test email on root failed.
