### PR TITLE
Bug/2281 reconnect in worker

### DIFF
--- a/pool/app/invitation/dune
+++ b/pool/app/invitation/dune
@@ -2,6 +2,6 @@
  (name invitation)
  (libraries contact experiment filter mailing pool_common sihl sihl-email)
  (preprocess
-  (pps lwt_ppx ppx_deriving.eq ppx_deriving.show)))
+  (pps lwt_ppx ppx_deriving.eq ppx_deriving.show ppx_string)))
 
 (include_subdirs unqualified)

--- a/pool/database/database.mli
+++ b/pool/database/database.mli
@@ -270,7 +270,7 @@ module Pool : sig
     -> (t, Pool_message.Error.t) Lwt_result.t
 
   val connect : Label.t -> (unit, Pool_message.Error.t) Lwt_result.t
-  val disconnect : ?error:Caqti_error.t -> Entity.Label.t -> unit Lwt.t
+  val disconnect : ?error:Caqti_error.t -> Label.t -> unit Lwt.t
   val all : ?allowed_status:Status.t list -> ?exclude:Label.t list -> unit -> Label.t list
   val is_root : Label.t -> bool
 

--- a/pool/database/pools.ml
+++ b/pool/database/pools.ml
@@ -206,7 +206,6 @@ module Make (Config : Pools_sig.ConfigSig) = struct
       | Ok resp -> Lwt.return resp
       | Error `Unsupported -> raise Pool_message.Error.(Exn (Unsupported "Caqti error"))
       | Error (#load_or_connect as err) ->
-        Logs.info (fun m -> m "ERROR load or connect: %s" (Caqti_error.show err));
         let%lwt () = disconnect ~error:err label in
         let () = Cache.log_pools () in
         raise (Exn err)

--- a/pool/pool_queue/repo.ml
+++ b/pool/pool_queue/repo.ml
@@ -41,6 +41,7 @@ let sql_select_columns ?(decode = true) table =
   ; go "last_error_at"
   ; go "database_label"
   ; go_binary "clone_of"
+  ; go "created_at"
   ]
 ;;
 
@@ -157,7 +158,11 @@ let count_all_workable_request =
 ;;
 
 let count_all_workable label =
-  Database.find_opt label count_all_workable_request ()
+  Lwt.catch
+    (fun () -> Database.find_opt label count_all_workable_request ())
+    (function
+      | Caqti_error.(Exn #load_or_connect) -> Lwt.return_none
+      | exn -> Lwt.reraise exn)
   ||> CCOption.get_or ~default:0
   ||> CCResult.return
 ;;


### PR DESCRIPTION
- resets database connection to "close" before retry

The worker got stuck with a "failed" connection as soon as the connection was missing once.
The retry just answered with the previously cached error.