### PR TITLE
allow queue job to be mapped to multiple entities

### DIFF
--- a/pool/app/pool_database/migrations/migration_202503061915.ml
+++ b/pool/app/pool_database/migrations/migration_202503061915.ml
@@ -1,0 +1,59 @@
+let drop_falsy_unique_constraints_assignments =
+  Database.Migration.Step.create
+    ~label:"drop_falsy_unique_constraints_assignments"
+    [%string
+      {sql|
+        ALTER TABLE pool_queue_job_assignment
+        DROP INDEX unique_queue_uuid;
+      |sql}]
+;;
+
+let drop_falsy_unique_constraints_experiment =
+  Database.Migration.Step.create
+    ~label:"drop_falsy_unique_constraints_experiment"
+    [%string
+      {sql|
+        ALTER TABLE pool_queue_job_experiment
+        DROP INDEX unique_queue_uuid;
+      |sql}]
+;;
+
+let drop_falsy_unique_constraints_invitation =
+  Database.Migration.Step.create
+    ~label:"drop_falsy_unique_constraints_invitation"
+    [%string
+      {sql|
+        ALTER TABLE pool_queue_job_invitation
+        DROP INDEX unique_queue_uuid;
+      |sql}]
+;;
+
+let drop_falsy_unique_constraints_session =
+  Database.Migration.Step.create
+    ~label:"drop_falsy_unique_constraints_session"
+    [%string
+      {sql|
+        ALTER TABLE pool_queue_job_session
+        DROP INDEX unique_queue_uuid;
+      |sql}]
+;;
+
+let drop_falsy_unique_constraints_user =
+  Database.Migration.Step.create
+    ~label:"drop_falsy_unique_constraints_user"
+    [%string
+      {sql|
+        ALTER TABLE pool_queue_job_user
+        DROP INDEX unique_queue_uuid;
+      |sql}]
+;;
+
+let migration () =
+  Database.Migration.(
+    empty "202503061915"
+    |> add_step drop_falsy_unique_constraints_assignments
+    |> add_step drop_falsy_unique_constraints_experiment
+    |> add_step drop_falsy_unique_constraints_invitation
+    |> add_step drop_falsy_unique_constraints_session
+    |> add_step drop_falsy_unique_constraints_user)
+;;

--- a/pool/app/pool_database/tenant.ml
+++ b/pool/app/pool_database/tenant.ml
@@ -79,6 +79,7 @@ let steps =
       ; Migration_202502100919.migration ()
       ; Migration_202502101715.migration ()
       ; Migration_202502271318.migration ()
+      ; Migration_202503061915.migration ()
       ]
     |> sort
   in


### PR DESCRIPTION
One queue job can currently only be mapped to one entity.

Currently, in the case of assignments, this is not correct (one job can be assigned to multiple assignments, for example).

Removing this constraint, as there is a unique constraint regarding the combination of job and entity.